### PR TITLE
Initial WinShirt plugin scaffolding

### DIFF
--- a/assets/css/winshirt.css
+++ b/assets/css/winshirt.css
@@ -1,0 +1,25 @@
+#winshirt-modal {
+    position: fixed;
+    z-index: 9999;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.5);
+}
+
+.winshirt-modal-content {
+    background-color: #fff;
+    margin: 10% auto;
+    padding: 20px;
+    width: 80%;
+    max-width: 600px;
+}
+
+.winshirt-close {
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}

--- a/assets/js/winshirt.js
+++ b/assets/js/winshirt.js
@@ -1,0 +1,14 @@
+jQuery(function($) {
+    var modal = $('#winshirt-modal');
+    var btn = $('#winshirt-customize');
+    var span = $('<span class="winshirt-close">&times;</span>');
+
+    btn.on('click', function(e) {
+        e.preventDefault();
+        modal.show();
+    });
+
+    modal.on('click', '.winshirt-close', function() {
+        modal.hide();
+    });
+});

--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -1,0 +1,44 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class WinShirt_Product_Customization {
+    public function __construct() {
+        // add product option
+        add_action('woocommerce_product_options_general_product_data', array($this, 'add_custom_option')); 
+        add_action('woocommerce_process_product_meta', array($this, 'save_custom_option'));
+        // display button
+        add_action('woocommerce_single_product_summary', array($this, 'display_customize_button'), 35);
+        // enqueue assets
+        add_action('wp_enqueue_scripts', array($this, 'enqueue_assets'));
+    }
+
+    public function add_custom_option() {
+        woocommerce_wp_checkbox(array(
+            'id' => '_winshirt_enable_custom',
+            'label' => __('Enable WinShirt customization', 'winshirt'),
+        ));
+    }
+
+    public function save_custom_option($post_id) {
+        $value = isset($_POST['_winshirt_enable_custom']) ? 'yes' : 'no';
+        update_post_meta($post_id, '_winshirt_enable_custom', $value);
+    }
+
+    public function display_customize_button() {
+        global $product;
+        $enabled = get_post_meta($product->get_id(), '_winshirt_enable_custom', true);
+        if ($enabled === 'yes') {
+            echo '<button id="winshirt-customize" class="button">' . esc_html__('Customize this product', 'winshirt') . '</button>';
+            echo '<div id="winshirt-modal" style="display:none;" class="winshirt-modal"><div class="winshirt-modal-content"><span class="winshirt-close">&times;</span><p>' . esc_html__('Customization interface coming soon...', 'winshirt') . '</p></div></div>';
+        }
+    }
+
+    public function enqueue_assets() {
+        if (is_product()) {
+            wp_enqueue_style('winshirt-styles', plugins_url('../assets/css/winshirt.css', __FILE__));
+            wp_enqueue_script('winshirt-script', plugins_url('../assets/js/winshirt.js', __FILE__), array('jquery'), null, true);
+        }
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,9 @@
+=== WinShirt ===
+Contributors: alanvalensi
+Tags: woocommerce, customization, lottery
+Requires at least: 6.5
+Tested up to: 6.5
+Stable tag: 1.0.0
+License: GPLv2 or later
+
+WinShirt allows WooCommerce products to be customized with a modal interface and lays the groundwork for lottery management.

--- a/winshirt.php
+++ b/winshirt.php
@@ -1,8 +1,25 @@
 <?php
 /**
  * Plugin Name: WinShirt
- * Description: Plugin WordPress pour personnalisation textile + loteries
+ * Description: Plugin WordPress pour personnalisation textile et gestion de loteries.
  * Version: 1.0.0
  * Author: Alan Valensi
  */
-if (!defined('ABSPATH')) exit;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('WINSHIRT_VERSION', '1.0.0');
+define('WINSHIRT_PATH', plugin_dir_path(__FILE__));
+
+autoload();
+
+function autoload() {
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
+}
+
+function winshirt_init() {
+    new WinShirt_Product_Customization();
+}
+add_action('plugins_loaded', 'winshirt_init');


### PR DESCRIPTION
## Summary
- set up base plugin structure
- add WooCommerce product option to enable WinShirt customization
- show customizable button and modal on product pages
- add minimal JS/CSS assets
- add project readme

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-product-customization.php`


------
https://chatgpt.com/codex/tasks/task_e_688ba6185f54832998841c6c667e11e6