### PR TITLE
Add modal customization framework

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -1,0 +1,36 @@
+#winshirt-customizer-modal {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    overflow: auto;
+}
+#winshirt-customizer-modal .modal-overlay {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+#winshirt-customizer-modal .modal-content {
+    background: #fff;
+    width: 90%;
+    max-width: 1000px;
+    margin: auto;
+    position: relative;
+    padding: 1rem;
+    box-sizing: border-box;
+}
+#winshirt-customizer-modal .winshirt-modal-close {
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var modal = document.getElementById('winshirt-customizer-modal');
+
+    function openModal() {
+        if (modal) {
+            modal.style.display = 'block';
+        }
+    }
+
+    function closeModal() {
+        if (modal) {
+            modal.style.display = 'none';
+        }
+    }
+
+    document.body.addEventListener('click', function (e) {
+        if (e.target.classList.contains('btn-personnaliser')) {
+            e.preventDefault();
+            openModal();
+        }
+        if (e.target.classList.contains('winshirt-modal-close') || e.target === modal) {
+            closeModal();
+        }
+    });
+
+    window.openModal = openModal;
+    window.closeModal = closeModal;
+});

--- a/includes/class-winshirt-modal.php
+++ b/includes/class-winshirt-modal.php
@@ -1,0 +1,54 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class WinShirt_Modal {
+
+    public function __construct() {
+        add_action('woocommerce_single_product_summary', array($this, 'insert_button'), 31);
+        add_action('wp_footer', array($this, 'add_modal_template'));
+        add_action('wp_enqueue_scripts', array($this, 'enqueue_assets'));
+    }
+
+    private function is_customizable_product() {
+        if (!is_product()) {
+            return false;
+        }
+        global $product;
+        if (!$product) {
+            return false;
+        }
+        return get_post_meta($product->get_id(), '_winshirt_personnalisable', true) === 'yes';
+    }
+
+    public function insert_button() {
+        if ($this->is_customizable_product()) {
+            echo '<button type="button" class="btn-personnaliser">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+        }
+    }
+
+    public function add_modal_template() {
+        if ($this->is_customizable_product()) {
+            include WINSHIRT_PATH . 'templates/modal-customizer.php';
+        }
+    }
+
+    public function enqueue_assets() {
+        if ($this->is_customizable_product()) {
+            wp_enqueue_style(
+                'winshirt-modal',
+                plugins_url('../assets/css/winshirt-modal.css', __FILE__),
+                array(),
+                WINSHIRT_VERSION
+            );
+            wp_enqueue_script(
+                'winshirt-modal',
+                plugins_url('../assets/js/winshirt-modal.js', __FILE__),
+                array(),
+                WINSHIRT_VERSION,
+                true
+            );
+        }
+    }
+}

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -1,0 +1,15 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div id="winshirt-customizer-modal" style="display: none;">
+    <div class="modal-overlay">
+        <div class="modal-content">
+            <button type="button" class="winshirt-modal-close">&times;</button>
+            <div class="winshirt-customizer-body">
+                <p><?php esc_html_e('Interface de personnalisation', 'winshirt'); ?></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/winshirt.php
+++ b/winshirt.php
@@ -17,9 +17,11 @@ autoload();
 
 function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-modal.php';
 }
 
 function winshirt_init() {
     new WinShirt_Product_Customization();
+    new WinShirt_Modal();
 }
 add_action('plugins_loaded', 'winshirt_init');


### PR DESCRIPTION
## Summary
- implement product personalization modal markup and JS
- conditionally show modal on products with `_winshirt_personnalisable` meta
- enqueue dedicated CSS/JS only for customizable products
- load modal template in the footer and add "Personnaliser" button
- update plugin loader to include new class

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-modal.php`
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_688bd5dd132c8329be12967d0179614c