### PR TITLE
Add basic admin menu

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class WinShirt_Admin {
+    public function __construct() {
+        add_action('admin_menu', array($this, 'add_menu'));
+    }
+
+    public function add_menu() {
+        add_menu_page(
+            __('WinShirt', 'winshirt'),
+            __('WinShirt', 'winshirt'),
+            'manage_options',
+            'winshirt',
+            array($this, 'display_page'),
+            'dashicons-admin-generic'
+        );
+    }
+
+    public function display_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('WinShirt Settings', 'winshirt') . '</h1>';
+        echo '<p>' . esc_html__('Admin interface coming soon...', 'winshirt') . '</p>';
+        echo '</div>';
+    }
+}
+
+?>

--- a/winshirt.php
+++ b/winshirt.php
@@ -18,10 +18,12 @@ autoload();
 function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-modal.php';
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-admin.php';
 }
 
 function winshirt_init() {
     new WinShirt_Product_Customization();
     new WinShirt_Modal();
+    new WinShirt_Admin();
 }
 add_action('plugins_loaded', 'winshirt_init');


### PR DESCRIPTION
## Summary
- add a new WinShirt_Admin class and load it
- instantiate the admin menu on plugin init

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-admin.php`
- `php -l includes/class-winshirt-modal.php`
- `php -l includes/class-winshirt-product-customization.php`


------
https://chatgpt.com/codex/tasks/task_e_688c47e6d11883299e7806fde6bde98f