### PR TITLE
Add plugin page links

### DIFF
--- a/winshirt.php
+++ b/winshirt.php
@@ -27,3 +27,12 @@ function winshirt_init() {
     new WinShirt_Admin();
 }
 add_action('plugins_loaded', 'winshirt_init');
+
+function winshirt_plugin_row_meta($links, $file) {
+    if ($file === plugin_basename(__FILE__)) {
+        $links[] = '<a href="https://shakass.com/" target="_blank">' . esc_html__('Site Web', 'winshirt') . '</a>';
+        $links[] = '<a href="' . esc_url(plugins_url('readme.txt', __FILE__)) . '" target="_blank">' . esc_html__('Readme', 'winshirt') . '</a>';
+    }
+    return $links;
+}
+add_filter('plugin_row_meta', 'winshirt_plugin_row_meta', 10, 2);


### PR DESCRIPTION
## Summary
- show plugin metadata links on the Plugins page

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-admin.php`
- `php -l includes/class-winshirt-modal.php`
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_688c63d580a08329b473396576948232