### PR TITLE
Fix deploy path for plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,5 +39,6 @@ jobs:
           password:         ${{ secrets.SFTP_PASSWORD }}
           port:             ${{ secrets.SFTP_PORT }}
           source:           "./"
-          target:           "wp-content/plugins/winshirt"
+          # Chemin absolu identique à celui utilisé pour le nettoyage
+          target:           "/homepages/45/d408430562/htdocs/wp-content/plugins/winshirt"
           strip_components: 1


### PR DESCRIPTION
## Summary
- ensure the SCP step uploads to the correct absolute directory

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-product-customization.php`
- `php -l includes/class-winshirt-modal.php`
- `php -l includes/class-winshirt-admin.php`
- `yamllint .github/workflows/deploy.yml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688c8e69113483298cb82ad86bdce33e