### PR TITLE
Fix missing init method causing fatal error

### DIFF
--- a/includes/class-winshirt-modal.php
+++ b/includes/class-winshirt-modal.php
@@ -4,6 +4,14 @@ if (!defined('ABSPATH')) {
 }
 
 class WinShirt_Modal {
+    /**
+     * Initialise les hooks du module.
+     *
+     * @return self
+     */
+    public static function init() {
+        return new self();
+    }
 
     public function __construct() {
         add_action('woocommerce_single_product_summary', array($this, 'insert_button'), 31);


### PR DESCRIPTION
## Summary
- add `init` method to `WinShirt_Modal` class

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-modal.php`
- `php -l includes/class-winshirt-admin.php`
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_688ce5526eb483299aaf8cb05427b80d