### PR TITLE
Implement modal customizer with assets

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -1,36 +1,29 @@
-#winshirt-customizer-modal {
-    position: fixed;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9999;
-    background: rgba(0,0,0,0.6);
-    display: none;
-    overflow: auto;
+.winshirt-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.6);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-#winshirt-customizer-modal .modal-overlay {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.winshirt-modal-content {
+  background: white;
+  width: 90%;
+  max-width: 1200px;
+  height: 90%;
+  overflow: auto;
+  border-radius: 8px;
+  position: relative;
 }
-#winshirt-customizer-modal .modal-content {
-    background: #fff;
-    width: 90%;
-    max-width: 1000px;
-    margin: auto;
-    position: relative;
-    padding: 1rem;
-    box-sizing: border-box;
+/* Bouton fermer */
+.winshirt-modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: transparent;
+  border: none;
+  font-size: 28px;
+  cursor: pointer;
 }
-#winshirt-customizer-modal .winshirt-modal-close {
-    position: absolute;
-    right: 1rem;
-    top: 1rem;
-    background: none;
-    border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
-}
+/* Réintègre ici tout le CSS que tu avais dans <style>, en préfixant chaque sélecteur par #winshirt-customizer-modal ou .winshirt-modal-content */

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,28 +1,27 @@
-document.addEventListener('DOMContentLoaded', function () {
-    var modal = document.getElementById('winshirt-customizer-modal');
+document.addEventListener('DOMContentLoaded', function() {
+  const openBtn  = document.getElementById('winshirt-open-modal');
+  const closeBtn = document.getElementById('winshirt-close-modal');
+  const modal    = document.getElementById('winshirt-customizer-modal');
 
-    function openModal() {
-        if (modal) {
-            modal.style.display = 'block';
-        }
+  if (!openBtn || !modal) return;
+
+  openBtn.addEventListener('click', () => {
+    modal.style.display = 'flex';
+    document.body.style.overflow = 'hidden'; // bloque scroll arrière-plan
+  });
+
+  closeBtn.addEventListener('click', () => {
+    modal.style.display = 'none';
+    document.body.style.overflow = '';
+  });
+
+  // Fermer au clic hors du contenu
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) {
+      modal.style.display = 'none';
+      document.body.style.overflow = '';
     }
+  });
 
-    function closeModal() {
-        if (modal) {
-            modal.style.display = 'none';
-        }
-    }
-
-    document.body.addEventListener('click', function (e) {
-        if (e.target.classList.contains('btn-personnaliser')) {
-            e.preventDefault();
-            openModal();
-        }
-        if (e.target.classList.contains('winshirt-modal-close') || e.target === modal) {
-            closeModal();
-        }
-    });
-
-    window.openModal = openModal;
-    window.closeModal = closeModal;
+  // (Pour la suite : intégrer interact.js, html2canvas, drag/resize…)
 });

--- a/includes/class-winshirt-modal.php
+++ b/includes/class-winshirt-modal.php
@@ -1,62 +1,55 @@
 <?php
-if (!defined('ABSPATH')) {
-    exit;
-}
+// includes/class-winshirt-modal.php
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 class WinShirt_Modal {
-    /**
-     * Initialise les hooks du module.
-     *
-     * @return self
-     */
-    public static function init() {
-        return new self();
-    }
 
     public function __construct() {
-        add_action('woocommerce_single_product_summary', array($this, 'insert_button'), 31);
-        add_action('wp_footer', array($this, 'add_modal_template'));
-        add_action('wp_enqueue_scripts', array($this, 'enqueue_assets'));
+        add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'add_button' ] );
+        add_action( 'wp_footer',                           [ $this, 'print_modal' ] );
+        add_action( 'wp_enqueue_scripts',                  [ $this, 'enqueue_assets' ] );
     }
 
-    private function is_customizable_product() {
-        if (!is_product()) {
-            return false;
-        }
-        global $product;
-        if (!$product) {
-            return false;
-        }
-        return get_post_meta($product->get_id(), '_winshirt_personnalisable', true) === 'yes';
-    }
-
-    public function insert_button() {
-        if ($this->is_customizable_product()) {
-            echo '<button type="button" class="btn-personnaliser">' . esc_html__( 'Personnaliser ce produit', 'winshirt' ) . '</button>';
+    public function add_button() {
+        if ( is_product() ) {
+            global $product;
+            if ( 'yes' === get_post_meta( $product->get_id(), '_winshirt_personnalisable', true ) ) {
+                echo '<button class="btn-personnaliser" id="winshirt-open-modal">Personnaliser ce produit</button>';
+            }
         }
     }
 
-    public function add_modal_template() {
-        if ($this->is_customizable_product()) {
-            include WINSHIRT_PATH . 'templates/modal-customizer.php';
+    public function print_modal() {
+        if ( is_product() ) {
+            global $product;
+            if ( 'yes' === get_post_meta( $product->get_id(), '_winshirt_personnalisable', true ) ) {
+                include WINSHIRT_PATH . 'templates/modal-customizer.php';
+            }
         }
     }
 
     public function enqueue_assets() {
-        if ($this->is_customizable_product()) {
-            wp_enqueue_style(
-                'winshirt-modal',
-                plugins_url('../assets/css/winshirt-modal.css', __FILE__),
-                array(),
-                WINSHIRT_VERSION
-            );
-            wp_enqueue_script(
-                'winshirt-modal',
-                plugins_url('../assets/js/winshirt-modal.js', __FILE__),
-                array(),
-                WINSHIRT_VERSION,
-                true
-            );
+        if ( is_product() ) {
+            global $product;
+            if ( 'yes' === get_post_meta( $product->get_id(), '_winshirt_personnalisable', true ) ) {
+                wp_enqueue_style(
+                    'winshirt-modal',
+                    plugins_url( 'assets/css/winshirt-modal.css', WINSHIRT_PATH . 'winshirt.php' ),
+                    [],
+                    WINSHIRT_VERSION
+                );
+                wp_enqueue_script(
+                    'winshirt-modal',
+                    plugins_url( 'assets/js/winshirt-modal.js', WINSHIRT_PATH . 'winshirt.php' ),
+                    [],
+                    WINSHIRT_VERSION,
+                    true
+                );
+            }
         }
     }
 }
+
+// Instanciation
+new WinShirt_Modal();
+

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -1,15 +1,17 @@
-<?php
-if (!defined('ABSPATH')) {
-    exit;
-}
-?>
-<div id="winshirt-customizer-modal" style="display: none;">
-    <div class="modal-overlay">
-        <div class="modal-content">
-            <button type="button" class="winshirt-modal-close">&times;</button>
-            <div class="winshirt-customizer-body">
-                <p><?php esc_html_e('Interface de personnalisation', 'winshirt'); ?></p>
-            </div>
-        </div>
+<div id="winshirt-customizer-modal" class="winshirt-modal-overlay" style="display:none;">
+  <div class="winshirt-modal-content">
+    <button class="winshirt-modal-close" id="winshirt-close-modal">&times;</button>
+    <div class="header"></div>
+    <div class="main-container">
+      <aside class="left-sidebar">
+        <!-- … tes tool-icons … -->
+      </aside>
+      <main class="central-area">
+        <!-- … tes view-controls, tshirt, zones … -->
+      </main>
+      <aside class="right-sidebar">
+        <!-- … galerie, upload … -->
+      </aside>
     </div>
+  </div>
 </div>

--- a/winshirt.php
+++ b/winshirt.php
@@ -23,7 +23,6 @@ function autoload() {
 
 function winshirt_init() {
     new WinShirt_Product_Customization();
-    WinShirt_Modal::init();             // ← appel statique
     new WinShirt_Admin();
 }
 add_action('plugins_loaded', 'winshirt_init');


### PR DESCRIPTION
## Summary
- Implement WinShirt_Modal class to inject customization button and modal assets
- Add modal-customizer template with overlay structure
- Provide CSS and JS for opening and closing the modal
- Remove obsolete static init call from plugin bootstrap

## Testing
- `php -l includes/class-winshirt-modal.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `node --check assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_688e293cd5f48329a98946501393d839