### PR TITLE
Add WinShirt settings page

### DIFF
--- a/includes/class-winshirt-settings.php
+++ b/includes/class-winshirt-settings.php
@@ -1,0 +1,184 @@
+<?php
+// includes/class-winshirt-settings.php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class WinShirt_Settings {
+
+    const OPTION_KEY = 'winshirt_settings';
+    const PAGE_SLUG  = 'winshirt-settings';
+
+    public static function init() {
+        add_action( 'admin_menu',   [ __CLASS__, 'add_settings_page' ] );
+        add_action( 'admin_init',   [ __CLASS__, 'register_settings' ] );
+    }
+
+    // 1. Ajouter le menu et la page
+    public static function add_settings_page() {
+        add_menu_page(
+            __( 'WinShirt Settings', 'winshirt' ),    // page title
+            __( 'WinShirt', 'winshirt' ),             // menu title
+            'manage_options',                         // capability
+            self::PAGE_SLUG,                          // menu slug
+            [ __CLASS__, 'render_settings_page' ],    // callback
+            'dashicons-admin-generic',                // icon
+            60                                        // position
+        );
+    }
+
+    // 2. Enregistrer les réglages (Settings API)
+    public static function register_settings() {
+        register_setting(
+            'winshirt_settings_group',                // option group
+            self::OPTION_KEY,                         // option name
+            [ __CLASS__, 'sanitize_settings' ]        // sanitize callback
+        );
+
+        add_settings_section(
+            'winshirt_section_main',                  // id
+            __( 'Paramètres généraux', 'winshirt' ),  // title
+            '__return_false',                         // callback description
+            self::PAGE_SLUG                           // page
+        );
+
+        // Champs : API IA
+        add_settings_field(
+            'ftp_api_ia_key',
+            __( 'Clé API IA', 'winshirt' ),
+            [ __CLASS__, 'field_api_key_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+
+        // Champs : Formats autorisés
+        add_settings_field(
+            'formats_allowed',
+            __( 'Formats autorisés', 'winshirt' ),
+            [ __CLASS__, 'field_formats_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+
+        // Champs : Dimensions par défaut
+        add_settings_field(
+            'dimensions_default',
+            __( 'Dimensions par défaut (L×H×U)', 'winshirt' ),
+            [ __CLASS__, 'field_dimensions_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+
+        // Champs : Préfixe export
+        add_settings_field(
+            'prefix_export',
+            __( 'Préfixe export', 'winshirt' ),
+            [ __CLASS__, 'field_prefix_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+
+        // Champs : Chemins export JSON/XML
+        add_settings_field(
+            'path_export_json',
+            __( 'Chemin export JSON', 'winshirt' ),
+            [ __CLASS__, 'field_path_json_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+        add_settings_field(
+            'path_export_xml',
+            __( 'Chemin export XML', 'winshirt' ),
+            [ __CLASS__, 'field_path_xml_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
+    }
+
+    // 3. Sanitize
+    public static function sanitize_settings( $input ) {
+        $output = [];
+        $output['api_ia_key']        = sanitize_text_field( $input['api_ia_key'] ?? '' );
+        $output['formats_allowed']   = sanitize_text_field( $input['formats_allowed'] ?? '' );
+        $output['dimensions_default']= sanitize_text_field( $input['dimensions_default'] ?? '' );
+        $output['prefix_export']     = sanitize_text_field( $input['prefix_export'] ?? '' );
+        $output['path_export_json']  = sanitize_text_field( $input['path_export_json'] ?? '' );
+        $output['path_export_xml']   = sanitize_text_field( $input['path_export_xml'] ?? '' );
+        return $output;
+    }
+
+    // 4. Callbacks pour chaque champ
+    public static function field_api_key_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[api_ia_key]" value="%2$s" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['api_ia_key'] ?? '' )
+        );
+    }
+
+    public static function field_formats_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[formats_allowed]" value="%2$s" placeholder="A4,A3,Coeur,Full" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['formats_allowed'] ?? '' )
+        );
+    }
+
+    public static function field_dimensions_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[dimensions_default]" value="%2$s" placeholder="100x150x1" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['dimensions_default'] ?? '' )
+        );
+    }
+
+    public static function field_prefix_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[prefix_export]" value="%2$s" placeholder="winshirt_" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['prefix_export'] ?? '' )
+        );
+    }
+
+    public static function field_path_json_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[path_export_json]" value="%2$s" placeholder="/exports/json/" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['path_export_json'] ?? '' )
+        );
+    }
+
+    public static function field_path_xml_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="text" name="%1$s[path_export_xml]" value="%2$s" placeholder="/exports/xml/" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['path_export_xml'] ?? '' )
+        );
+    }
+
+    // 5. Rendu de la page
+    public static function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Configuration WinShirt', 'winshirt' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'winshirt_settings_group' );
+                do_settings_sections( self::PAGE_SLUG );
+                submit_button( __( 'Enregistrer', 'winshirt' ) );
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+}
+
+// Lancement
+WinShirt_Settings::init();

--- a/winshirt.php
+++ b/winshirt.php
@@ -18,116 +18,13 @@ autoload();
 function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-modal.php';
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-settings.php';
 }
 
 function winshirt_init() {
     new WinShirt_Product_Customization();
 }
 add_action('plugins_loaded', 'winshirt_init');
-
-add_action('admin_menu', 'winshirt_register_settings_page');
-add_action('admin_init', 'winshirt_register_settings');
-
-function winshirt_register_settings_page() {
-    add_menu_page(
-        'WinShirt Settings',
-        'WinShirt',
-        'manage_options',
-        'winshirt-settings',
-        'winshirt_settings_page_html',
-        'dashicons-admin-generic',
-        60
-    );
-}
-
-function winshirt_register_settings() {
-    register_setting('winshirt_settings_group', 'winshirt_settings', 'winshirt_sanitize_settings');
-
-    add_settings_section(
-        'winshirt_settings_section_main',
-        __('Paramètres généraux', 'winshirt'),
-        'winshirt_settings_section_main_cb',
-        'winshirt-settings'
-    );
-
-    add_settings_field(
-        'winshirt_ftp_host',
-        __('FTP Host', 'winshirt'),
-        'winshirt_field_ftp_host_cb',
-        'winshirt-settings',
-        'winshirt_settings_section_main'
-    );
-
-    add_settings_field(
-        'winshirt_ftp_user',
-        __('FTP Username', 'winshirt'),
-        'winshirt_field_ftp_user_cb',
-        'winshirt-settings',
-        'winshirt_settings_section_main'
-    );
-
-    add_settings_field(
-        'winshirt_ftp_pass',
-        __('FTP Password', 'winshirt'),
-        'winshirt_field_ftp_pass_cb',
-        'winshirt-settings',
-        'winshirt_settings_section_main'
-    );
-}
-
-function winshirt_sanitize_settings($input) {
-    $output = [];
-    $output['ftp_host'] = sanitize_text_field($input['ftp_host'] ?? '');
-    $output['ftp_user'] = sanitize_text_field($input['ftp_user'] ?? '');
-    $output['ftp_pass'] = sanitize_text_field($input['ftp_pass'] ?? '');
-    return $output;
-}
-
-function winshirt_settings_section_main_cb() {
-    echo '<p>' . esc_html__('Configurez les accès FTP et options IA.', 'winshirt') . '</p>';
-}
-
-function winshirt_field_ftp_host_cb() {
-    $opts = get_option('winshirt_settings');
-    printf(
-        '<input type="text" name="winshirt_settings[ftp_host]" value="%s" class="regular-text" />',
-        esc_attr($opts['ftp_host'] ?? '')
-    );
-}
-
-function winshirt_field_ftp_user_cb() {
-    $opts = get_option('winshirt_settings');
-    printf(
-        '<input type="text" name="winshirt_settings[ftp_user]" value="%s" class="regular-text" />',
-        esc_attr($opts['ftp_user'] ?? '')
-    );
-}
-
-function winshirt_field_ftp_pass_cb() {
-    $opts = get_option('winshirt_settings');
-    printf(
-        '<input type="password" name="winshirt_settings[ftp_pass]" value="%s" class="regular-text" />',
-        esc_attr($opts['ftp_pass'] ?? '')
-    );
-}
-
-function winshirt_settings_page_html() {
-    if (!current_user_can('manage_options')) {
-        return;
-    }
-
-    if (isset($_GET['settings-updated'])) {
-        add_settings_error('winshirt_messages', 'winshirt_message', __('Paramètres mis à jour.', 'winshirt'), 'updated');
-    }
-    settings_errors('winshirt_messages');
-
-    echo '<div class="wrap"><h1>' . esc_html__('Configuration WinShirt', 'winshirt') . '</h1>';
-    echo '<form action="options.php" method="post">';
-    settings_fields('winshirt_settings_group');
-    do_settings_sections('winshirt-settings');
-    submit_button(__('Enregistrer', 'winshirt'));
-    echo '</form></div>';
-}
 
 function winshirt_plugin_row_meta($links, $file) {
     if ($file === plugin_basename(__FILE__)) {


### PR DESCRIPTION
## Summary
- Add a `WinShirt_Settings` class to manage plugin configuration options and admin page
- Require the new settings class in the plugin autoloader and remove legacy FTP settings

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_688e37f356188329bfd610453f5fc114