### PR TITLE
Send lottery participants list to bailiff via AJAX

### DIFF
--- a/assets/js/admin-lottery.js
+++ b/assets/js/admin-lottery.js
@@ -1,0 +1,23 @@
+jQuery( function( $ ) {
+  $('#winshirt-send-participants').on('click', function() {
+    var postId = $(this).data('post-id');
+    var nonce  = $('input[name="winshirt_send_lottery_nonce"]').val();
+    var status = $('#winshirt-send-status').text( 'Envoi…' );
+
+    $.post( WinShirtLottery.ajaxUrl, {
+      action: WinShirtLottery.action,
+      post_id: postId,
+      nonce: nonce
+    })
+    .done(function( res ) {
+      if ( res.success ) {
+        status.text( res.data );
+      } else {
+        status.text( res.data || 'Erreur' );
+      }
+    })
+    .fail(function() {
+      status.text( 'Erreur AJAX' );
+    });
+  });
+});

--- a/includes/class-winshirt-lottery.php
+++ b/includes/class-winshirt-lottery.php
@@ -4,7 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 class WinShirt_Lottery {
 
-    const TAX_SLUG = 'loterie';
+    const TAX_SLUG    = 'loterie';
+    const AJAX_ACTION = 'winshirt_send_lottery_participants';
 
     public static function init() {
         add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
@@ -12,6 +13,11 @@ class WinShirt_Lottery {
         add_action( 'save_post', [ __CLASS__, 'save_lottery_meta' ], 10, 2 );
         add_filter( 'manage_posts_columns', [ __CLASS__, 'add_columns' ], 10, 2 );
         add_action( 'manage_posts_custom_column', [ __CLASS__, 'render_columns' ], 10, 2 );
+
+        // Hooks pour l'envoi des participants
+        add_action( 'edit_form_after_title', [ __CLASS__, 'render_send_button' ] );
+        add_action( 'admin_enqueue_scripts',  [ __CLASS__, 'enqueue_admin_script' ] );
+        add_action( 'wp_ajax_' . self::AJAX_ACTION, [ __CLASS__, 'ajax_send_participants' ] );
     }
 
     // 1) Taxonomie « Loterie » attachée aux articles
@@ -100,6 +106,101 @@ class WinShirt_Lottery {
             }, $ids );
             echo esc_html( implode( ', ', $titles ) );
         }
+    }
+
+    /**
+     * Affiche un bouton d'envoi pour les posts de type 'post' ayant la taxonomie 'loterie'
+     */
+    public static function render_send_button( $post ) {
+        if ( $post->post_type !== 'post' ) {
+            return;
+        }
+        if ( ! has_term( '', self::TAX_SLUG, $post ) ) {
+            return;
+        }
+
+        wp_nonce_field( 'winshirt_send_lottery', 'winshirt_send_lottery_nonce' );
+        echo '<div style="margin:10px 0;">';
+        echo '<button type="button" class="button button-primary" id="winshirt-send-participants" data-post-id="' . esc_attr( $post->ID ) . '">' . __( 'Envoyer la liste des participants à l’huissier', 'winshirt' ) . '</button>';
+        echo '<span id="winshirt-send-status" style="margin-left:10px;"></span>';
+        echo '</div>';
+    }
+
+    /**
+     * Injecte le JS admin nécessaire
+     */
+    public static function enqueue_admin_script( $hook ) {
+        if ( $hook !== 'post.php' && $hook !== 'post-new.php' ) {
+            return;
+        }
+        wp_enqueue_script(
+            'winshirt-lottery-admin',
+            plugins_url( 'assets/js/admin-lottery.js', WINSHIRT_PATH . 'winshirt.php' ),
+            [ 'jquery' ],
+            WINSHIRT_VERSION,
+            true
+        );
+        wp_localize_script(
+            'winshirt-lottery-admin',
+            'WinShirtLottery',
+            [
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+                'action'  => self::AJAX_ACTION,
+            ]
+        );
+    }
+
+    /**
+     * Handler AJAX pour compiler et envoyer la liste
+     */
+    public static function ajax_send_participants() {
+        if ( ! current_user_can( 'edit_posts' )
+            || ! isset( $_POST['nonce'] )
+            || ! wp_verify_nonce( $_POST['nonce'], 'winshirt_send_lottery' )
+            || empty( $_POST['post_id'] ) ) {
+            wp_send_json_error( __( 'Accès refusé', 'winshirt' ), 403 );
+        }
+
+        $post_id = intval( $_POST['post_id'] );
+
+        $products = get_post_meta( $post_id, '_winshirt_lottery_products', true );
+        if ( empty( $products ) ) {
+            wp_send_json_error( __( 'Aucun participant défini.', 'winshirt' ), 400 );
+        }
+
+        $participants = [];
+        foreach ( $products as $prod_id ) {
+            $orders = wc_get_orders([
+                'limit'      => -1,
+                'status'     => [ 'pending', 'processing', 'completed' ],
+                'product_id' => $prod_id,
+            ]);
+            foreach ( $orders as $order ) {
+                $email = $order->get_billing_email();
+                $name  = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
+                $participants[ $email ] = $name;
+            }
+        }
+        if ( empty( $participants ) ) {
+            wp_send_json_error( __( 'Aucun joueur trouvé.', 'winshirt' ), 404 );
+        }
+
+        $body  = 'Liste des participants pour la loterie « ' . get_the_title( $post_id ) . " » :\n\n";
+        foreach ( $participants as $email => $name ) {
+            $body .= sprintf( '- %s <%s>\n', $name, $email );
+        }
+
+        $settings = get_option( 'winshirt_settings', [] );
+        $to = $settings['bailiff_email'] ?? get_option( 'admin_email' );
+
+        $subject = sprintf( 'Participants Loterie : %s', get_the_title( $post_id ) );
+        $sent = wp_mail( $to, $subject, $body );
+
+        if ( ! $sent ) {
+            wp_send_json_error( __( 'Échec de l’envoi.', 'winshirt' ), 500 );
+        }
+
+        wp_send_json_success( __( 'Liste envoyée !', 'winshirt' ) );
     }
 }
 

--- a/includes/class-winshirt-settings.php
+++ b/includes/class-winshirt-settings.php
@@ -91,6 +91,15 @@ class WinShirt_Settings {
             self::PAGE_SLUG,
             'winshirt_section_main'
         );
+
+        // Champs : Email huissier
+        add_settings_field(
+            'bailiff_email',
+            __( 'Email huissier', 'winshirt' ),
+            [ __CLASS__, 'field_bailiff_email_cb' ],
+            self::PAGE_SLUG,
+            'winshirt_section_main'
+        );
     }
 
     // 3. Sanitize
@@ -102,6 +111,7 @@ class WinShirt_Settings {
         $output['prefix_export']     = sanitize_text_field( $input['prefix_export'] ?? '' );
         $output['path_export_json']  = sanitize_text_field( $input['path_export_json'] ?? '' );
         $output['path_export_xml']   = sanitize_text_field( $input['path_export_xml'] ?? '' );
+        $output['bailiff_email']     = sanitize_email( $input['bailiff_email'] ?? '' );
         return $output;
     }
 
@@ -157,6 +167,15 @@ class WinShirt_Settings {
             '<input type="text" name="%1$s[path_export_xml]" value="%2$s" placeholder="/exports/xml/" class="regular-text" />',
             esc_attr( self::OPTION_KEY ),
             esc_attr( $opts['path_export_xml'] ?? '' )
+        );
+    }
+
+    public static function field_bailiff_email_cb() {
+        $opts = get_option( self::OPTION_KEY );
+        printf(
+            '<input type="email" name="%1$s[bailiff_email]" value="%2$s" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $opts['bailiff_email'] ?? '' )
         );
     }
 


### PR DESCRIPTION
## Summary
- add admin button to send lottery participants to bailiff
- implement AJAX handler compiling participants and emailing bailiff
- add settings field for bailiff email and admin JS to trigger send

## Testing
- `php -l includes/class-winshirt-lottery.php`
- `php -l includes/class-winshirt-settings.php`
- `node --check assets/js/admin-lottery.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_688e402c9e40832982a490f471addcda