### PR TITLE
Add product customization modal and assets

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -1,29 +1,31 @@
-.winshirt-modal-overlay {
+/* overlay */
+#winshirt-modal-overlay {
   position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 10000;
+  top: 0; left: 0;
+  width:100%; height:100%;
+  background: rgba(0,0,0,0.5);
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 9999;
 }
-.winshirt-modal-content {
-  background: white;
-  width: 90%;
-  max-width: 1200px;
-  height: 90%;
-  overflow: auto;
+/* container */
+#winshirt-modal-container {
+  background: #fff;
   border-radius: 8px;
+  width: 90%;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow: auto;
   position: relative;
+  padding: 20px;
 }
-/* Bouton fermer */
-.winshirt-modal-close {
+/* close button */
+#winshirt-modal-close {
   position: absolute;
-  top: 16px;
-  right: 16px;
-  background: transparent;
+  top: 10px; right: 10px;
+  font-size: 24px;
+  background: none;
   border: none;
-  font-size: 28px;
   cursor: pointer;
 }
-/* Réintègre ici tout le CSS que tu avais dans <style>, en préfixant chaque sélecteur par #winshirt-customizer-modal ou .winshirt-modal-content */

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -1,27 +1,22 @@
-document.addEventListener('DOMContentLoaded', function() {
-  const openBtn  = document.getElementById('winshirt-open-modal');
-  const closeBtn = document.getElementById('winshirt-close-modal');
-  const modal    = document.getElementById('winshirt-customizer-modal');
+jQuery(function($){
+  var $overlay = $('#winshirt-modal-overlay'),
+      $open    = $('#winshirt-open-modal'),
+      $close   = $('#winshirt-modal-close');
 
-  if (!openBtn || !modal) return;
-
-  openBtn.addEventListener('click', () => {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden'; // bloque scroll arrière-plan
+  $open.on('click', function(e){
+    e.preventDefault();
+    $overlay.fadeIn(200);
+    // TODO: ici lancer init de la librairie de personnalisation (canvas/SVG)
   });
 
-  closeBtn.addEventListener('click', () => {
-    modal.style.display = 'none';
-    document.body.style.overflow = '';
+  $close.on('click', function(){
+    $overlay.fadeOut(200);
   });
 
-  // Fermer au clic hors du contenu
-  modal.addEventListener('click', (e) => {
-    if (e.target === modal) {
-      modal.style.display = 'none';
-      document.body.style.overflow = '';
+  // fermer au clic en dehors du container
+  $overlay.on('click', function(e){
+    if ( e.target === this ) {
+      $overlay.fadeOut(200);
     }
   });
-
-  // (Pour la suite : intégrer interact.js, html2canvas, drag/resize…)
 });

--- a/winshirt.php
+++ b/winshirt.php
@@ -22,11 +22,6 @@ function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';
 }
 
-function winshirt_init() {
-    new WinShirt_Product_Customization();
-}
-add_action('plugins_loaded', 'winshirt_init');
-
 function winshirt_plugin_row_meta($links, $file) {
     if ($file === plugin_basename(__FILE__)) {
         $links[] = '<a href="https://shakass.com/" target="_blank">' . esc_html__('Site Web', 'winshirt') . '</a>';


### PR DESCRIPTION
## Summary
- add WinShirt_Product_Customization class with meta box, modal, and asset enqueuing
- include product customization class in autoloader
- add modal CSS and jQuery script

## Testing
- `php -l includes/class-winshirt-product-customization.php`
- `php -l winshirt.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e42e0efc88329af65363c994577ae