### PR TITLE
Fix nonce field name to save product personalization

### DIFF
--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -30,7 +30,7 @@ class WinShirt_Product_Customization {
     }
 
     public function render_personalizable_metabox( $post ) {
-        wp_nonce_field( 'winshirt_save_personalizable', 'winshirt_personalizable_nonce' );
+        wp_nonce_field( 'winshirt_save_personalizable', 'winshirt_personnalisable_nonce' );
         $checked = get_post_meta( $post->ID, self::META_KEY, true ) === 'yes' ? 'checked' : '';
         echo '<label><input type="checkbox" name="winshirt_personnalisable" value="yes" ' . $checked . '/> '
             . esc_html__( 'Produit personnalisable', 'winshirt' )


### PR DESCRIPTION
## Summary
- ensure product personalization checkbox saves by using matching nonce field name

## Testing
- `php -l includes/class-winshirt-product-customization.php`


------
https://chatgpt.com/codex/tasks/task_e_688efab14e7883299770b824d6205527