### PR TITLE
Fix duplicate personalize button

### DIFF
--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -62,7 +62,7 @@ class WinShirt_Product_Customization {
             return;
         }
 
-        echo '<button id="winshirt-open-modal" class="button alt">'
+        echo '<button id="winshirt-open-modal" class="button alt" type="button">'
              . esc_html__( 'Personnaliser ce produit', 'winshirt' )
              . '</button>';
     }

--- a/winshirt.php
+++ b/winshirt.php
@@ -17,7 +17,6 @@ autoload();
 
 function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
-    require_once WINSHIRT_PATH . 'includes/class-winshirt-modal.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-settings.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';
 }


### PR DESCRIPTION
## Summary
- avoid loading legacy modal class that duplicated product customization button
- prevent modal button from acting like Add to Cart by adding `type="button"`

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-product-customization.php`


------
https://chatgpt.com/codex/tasks/task_e_688efe18228c83299850a1b4141822b7