### PR TITLE
feat: add roadmap progress admin page

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -4,6 +4,21 @@ if (!defined('ABSPATH')) {
 }
 
 class WinShirt_Admin {
+
+    private $roadmap_steps = array(
+        'initialization' => 'Initialisation & structure de base',
+        'configuration'  => 'Configuration globale',
+        'customization'  => 'Personnalisation produit',
+        'modal'          => 'Modal de personnalisation (prestations frontend)',
+        'editor'         => 'Éditeur d’éléments',
+        'capture'        => 'Capture & sauvegarde',
+        'mockups'        => 'Mockups produits',
+        'visuals'        => 'Visuels clients',
+        'orders'         => 'Commandes DTF',
+        'tests'          => 'Tests & validation',
+        'documentation'  => 'Documentation & publication'
+    );
+
     public function __construct() {
         add_action('admin_menu', array($this, 'add_menu'));
     }
@@ -14,17 +29,68 @@ class WinShirt_Admin {
             __('WinShirt', 'winshirt'),
             'manage_options',
             'winshirt',
-            array($this, 'display_page'),
+            array($this, 'settings_page'),
             'dashicons-admin-generic'
+        );
+
+        add_submenu_page(
+            'winshirt',
+            __('Avancement', 'winshirt'),
+            __('Avancement', 'winshirt'),
+            'manage_options',
+            'winshirt-progress',
+            array($this, 'progress_page')
         );
     }
 
-    public function display_page() {
+    public function settings_page() {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('WinShirt Settings', 'winshirt') . '</h1>';
         echo '<p>' . esc_html__('Admin interface coming soon...', 'winshirt') . '</p>';
         echo '</div>';
     }
-}
 
+    public function progress_page() {
+        $completed = get_option('winshirt_roadmap_progress', array());
+
+        if (isset($_POST['winshirt_roadmap'])) {
+            check_admin_referer('winshirt_progress_save', 'winshirt_progress_nonce');
+            $completed = array_map('sanitize_text_field', (array) $_POST['winshirt_roadmap']);
+            update_option('winshirt_roadmap_progress', $completed);
+        }
+
+        $total   = count($this->roadmap_steps);
+        $done    = count($completed);
+        $percent = $total > 0 ? round($done / $total * 100) : 0;
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Avancement du développement', 'winshirt') . '</h1>';
+        echo '<p>' . esc_html__('Progression :', 'winshirt') . ' <span id="winshirt-progress">' . esc_html($percent) . '%</span></p>';
+        echo '<form method="post">';
+        wp_nonce_field('winshirt_progress_save', 'winshirt_progress_nonce');
+        echo '<ul>';
+        foreach ($this->roadmap_steps as $key => $label) {
+            $checked = in_array($key, $completed, true) ? 'checked' : '';
+            echo '<li><label><input type="checkbox" class="winshirt-roadmap-checkbox" name="winshirt_roadmap[]" value="' . esc_attr($key) . '" ' . $checked . '> ' . esc_html($label) . '</label></li>';
+        }
+        echo '</ul>';
+        submit_button();
+        echo '</form>';
+        echo '<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const checkboxes = document.querySelectorAll(".winshirt-roadmap-checkbox");
+        const progress = document.getElementById("winshirt-progress");
+        const total = checkboxes.length;
+        function updateProgress() {
+            let checked = 0;
+            checkboxes.forEach(cb => { if (cb.checked) checked++; });
+            const percent = Math.round(checked / total * 100);
+            progress.textContent = percent + "%";
+        }
+        checkboxes.forEach(cb => cb.addEventListener("change", updateProgress));
+    });
+    </script>';
+        echo '</div>';
+    }
+}
 ?>

--- a/roadmap.txt
+++ b/roadmap.txt
@@ -1,0 +1,138 @@
+Plan de développement — Plugin WinShirt (Complet)
+
+Contexte & objectifs
+
+Le plugin WinShirt a pour vocation de permettre :
+
+La personnalisation textile (t-shirts, sweats, casquettes) directement depuis la fiche produit WooCommerce.
+
+La gestion de loteries associées aux produits, avec export des participants pour huissier.
+
+L’enregistrement, l’aperçu et la production des mockups et visuels clients.
+
+Un workflow DTF pour suivre l’état de production des commandes personnalisées.
+
+État actuel
+
+Déploiement automatisé via GitHub Actions → plugin synchronisé en FTP/Web
+
+Frontend minimal : bouton « Personnaliser ce produit » + modal vide
+
+Métabox produit « Personnalisable » opérationnelle (sauvegarde de la méta)
+
+Taxonomie « Loterie » sur Articles + bouton d’envoi participants
+
+Roadmap détaillée (ordre de priorité)
+
+1. Initialisation & structure de base
+
+Fichier principal (winshirt.php) : constantes, autoload des classes, hooks init
+
+Arborescence : includes/, assets/css, assets/js, templates/, admin/, .github/workflows
+
+Déploiement : confirmer le workflow GitHub Actions (SFTP ou SSH‑git pull)
+
+2. Configuration globale
+
+Menu WinShirt > Configuration
+
+Champs via Settings API : API IA, formats autorisés, dimensions par défaut, préfixes/chemins exports, email huissier
+
+Validation/sanitization des options
+
+3. Personnalisation produit
+
+Méta-box « Produit personnalisable » sur post-type product
+
+Méthode de sauvegarde : hook save_post, contrôle nonce, autosave, révisions, capabilities
+
+Bouton front : woocommerce_before_add_to_cart_button selon méta
+
+Impression des assets : CSS/JS pour modal chargé uniquement en produit personnalisé
+
+4. Modal de personnalisation (prestations frontend)
+
+Template PHP (templates/modal-customizer.php) avec ta structure HTML & classes exactes
+
+CSS externe (assets/css/winshirt-modal.css) reprenant intégralement ton code (styles, ombres, responsive)
+
+JS (assets/js/winshirt-modal.js) pour :
+
+Ouvrir/fermer modal (overlay, close, Esc)
+
+Switch outils (images, texte, calques, QR, IA)
+
+Switch face (front/back) et taille (A4, A3, cœur,…)
+
+Zone dynamique : <div class="design-area"> remplaçable par SVG ou canvas vierge
+
+5. Éditeur d’éléments
+
+Images : galerie + upload via File API ou media handle AJAX
+
+Texte : input, choix police, taille, couleur, style (gras, italique, souligné)
+
+QR Code : génération via JS et insertion directe
+
+IA : prompt → appel AJAX au serveur → inserion de l’image générée
+
+Calques : liste des éléments, ordre (drag & drop dans sidebar ou controls de profondeur)
+
+Drag & resize : utiliser une librairie (ex. interact.js) ou manipuler via JS natif
+
+6. Capture & sauvegarde
+
+html2canvas ou canvas.toBlob() pour générer :
+
+PNG basse résolution (preview)
+
+PNG HD (production)
+
+Enregistrement : send AJAX/REST à wc_add_order_item_meta ou update_post_meta
+
+Gestion des médias : stocker dans la médiathèque WP, attacher à l’ordre ou au produit
+
+7. Mockups produits
+
+Custom Post Type winshirt_mockup
+
+Liste avec colonnes produits, format, zones définies
+
+UI graphique pour dessiner/positionner les zones (x, y, width, height)
+
+Enregistrement en métadonnées
+
+8. Visuels clients
+
+Custom Post Type winshirt_visual ou métas dans order_item
+
+Galerie admin avec miniatures, date, produit, client
+
+Actions : télécharger PNG, supprimer, régénérer HD
+
+9. Commandes DTF
+
+Sous-menu Commandes DTF
+
+Table WP_List_Table listant les commandes personnalisées
+
+Filtres : statut (À produire, En cours, Expédié), date, client
+
+Bouton export JSON/XML pour huissier
+
+10. Tests & validation
+
+Tests unitaires (PHPUnit, WP-CLI) pour classes et fonctions critiques
+
+Tests fonctionnels (cypress, integration-tests) pour flux complet (personnalisation → commande)
+
+QA/UI : test responsiveness, accessibilité (ARIA), performance du modal
+
+11. Documentation & publication
+
+Documentation utilisateur (docs/): installation, configuration, tutoriel modal
+
+Readme.txt pour WordPress.org (Changelog, captures, FAQ)
+
+Préparation du zip pour dépôt sur WordPress.org
+

--- a/winshirt.php
+++ b/winshirt.php
@@ -19,6 +19,10 @@ function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-settings.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';
+    if (is_admin()) {
+        require_once WINSHIRT_PATH . 'includes/class-winshirt-admin.php';
+        new WinShirt_Admin();
+    }
 }
 
 function winshirt_plugin_row_meta($links, $file) {


### PR DESCRIPTION
## Summary
- add WinShirt admin progress page with roadmap checklist updating completion percentage
- load admin page when plugin runs in dashboard

## Testing
- `php -l includes/class-winshirt-admin.php`
- `php -l winshirt.php`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688f82597ad08329a028b2b8fda103ae