### PR TITLE
Wrap admin bootstrap in plugin hook

### DIFF
--- a/winshirt.php
+++ b/winshirt.php
@@ -21,7 +21,9 @@ function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';
     if (is_admin()) {
         require_once WINSHIRT_PATH . 'includes/class-winshirt-admin.php';
-        new WinShirt_Admin();
+        add_action('plugins_loaded', function () {
+            new WinShirt_Admin();
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- defer `WinShirt_Admin` instantiation until `plugins_loaded` to bootstrap admin features via WordPress hook.

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689077ff48e08329bbe5b515ee6e2fa5