### PR TITLE
feat: show progress page directly in menu

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -29,17 +29,17 @@ class WinShirt_Admin {
             __('WinShirt', 'winshirt'),
             'manage_options',
             'winshirt',
-            array($this, 'settings_page'),
+            array($this, 'progress_page'),
             'dashicons-admin-generic'
         );
 
         add_submenu_page(
             'winshirt',
-            __('Avancement', 'winshirt'),
-            __('Avancement', 'winshirt'),
+            __('Paramètres', 'winshirt'),
+            __('Paramètres', 'winshirt'),
             'manage_options',
-            'winshirt-progress',
-            array($this, 'progress_page')
+            'winshirt-settings',
+            array($this, 'settings_page')
         );
     }
 


### PR DESCRIPTION
## Summary
- show progress page as main WinShirt admin screen
- move existing settings placeholder to its own submenu

## Testing
- `php -l includes/class-winshirt-admin.php`
- `php -l winshirt.php`


------
https://chatgpt.com/codex/tasks/task_e_689079afc1048329a381f56b22d0fe95