### PR TITLE
feat: show progress page directly in menu

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -29,25 +29,18 @@ class WinShirt_Admin {
             __('WinShirt', 'winshirt'),
             'manage_options',
             'winshirt',
-            array($this, 'settings_page'),
+            array($this, 'progress_page'),
             'dashicons-admin-generic'
         );
 
         add_submenu_page(
             'winshirt',
-            __('Avancement', 'winshirt'),
-            __('Avancement', 'winshirt'),
+            __('Paramètres', 'winshirt'),
+            __('Paramètres', 'winshirt'),
             'manage_options',
-            'winshirt-progress',
-            array($this, 'progress_page')
+            'winshirt-settings',
+            ['WinShirt_Settings', 'render_settings_page']
         );
-    }
-
-    public function settings_page() {
-        echo '<div class="wrap">';
-        echo '<h1>' . esc_html__('WinShirt Settings', 'winshirt') . '</h1>';
-        echo '<p>' . esc_html__('Admin interface coming soon...', 'winshirt') . '</p>';
-        echo '</div>';
     }
 
     public function progress_page() {

--- a/includes/class-winshirt-settings.php
+++ b/includes/class-winshirt-settings.php
@@ -8,24 +8,12 @@ class WinShirt_Settings {
     const PAGE_SLUG  = 'winshirt-settings';
 
     public static function init() {
-        add_action( 'admin_menu',   [ __CLASS__, 'add_settings_page' ] );
-        add_action( 'admin_init',   [ __CLASS__, 'register_settings' ] );
+        // Register settings without adding a separate top-level menu. The menu
+        // entry is provided by \WinShirt_Admin.
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
     }
 
-    // 1. Ajouter le menu et la page
-    public static function add_settings_page() {
-        add_menu_page(
-            __( 'WinShirt Settings', 'winshirt' ),    // page title
-            __( 'WinShirt', 'winshirt' ),             // menu title
-            'manage_options',                         // capability
-            self::PAGE_SLUG,                          // menu slug
-            [ __CLASS__, 'render_settings_page' ],    // callback
-            'dashicons-admin-generic',                // icon
-            60                                        // position
-        );
-    }
-
-    // 2. Enregistrer les réglages (Settings API)
+    // Enregistrer les réglages (Settings API)
     public static function register_settings() {
         register_setting(
             'winshirt_settings_group',                // option group


### PR DESCRIPTION
## Summary
- show progress page as main WinShirt admin screen
- move settings under WinShirt menu and drop duplicate top-level entry

## Testing
- `php -l includes/class-winshirt-admin.php`
- `php -l includes/class-winshirt-settings.php`
- `php -l winshirt.php`


------
https://chatgpt.com/codex/tasks/task_e_689079afc1048329a381f56b22d0fe95