### PR TITLE
Add mockup manager with dynamic print zones

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -145,6 +145,9 @@
 }
 
 .design-area {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 600px;
   height: 650px;
   border: 3px dashed #dee2e6;
@@ -155,7 +158,6 @@
   color: #6c757d;
   font-size: 18px;
   background: rgba(248, 249, 250, 0.4);
-  position: relative;
 }
 
 .layer {
@@ -189,6 +191,24 @@
 .size-btn:hover {
   background: #f8f9fa;
   border-color: #007bff;
+}
+
+.color-controls {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.color-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid #dee2e6;
+  cursor: pointer;
+}
+
+.color-btn.active {
+  border: 2px solid #000;
 }
 
 /* Right Sidebar */

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -38,10 +38,14 @@ jQuery(function($){
   });
 
   const viewBtns = document.querySelectorAll('.view-btn');
+  const tshirt = document.querySelector('.tshirt');
   viewBtns.forEach(btn => {
     btn.addEventListener('click', function(){
       viewBtns.forEach(b => b.classList.remove('active'));
       this.classList.add('active');
+      if (tshirt && this.dataset.img) {
+        tshirt.style.backgroundImage = `url('${this.dataset.img}')`;
+      }
     });
   });
 
@@ -78,6 +82,7 @@ jQuery(function($){
   const colorOptions = document.querySelectorAll('.color-option');
   const styleBtns = document.querySelectorAll('.style-btn');
   const addTextBtn = document.getElementById('add-text-btn');
+  const mockupColors = document.querySelectorAll('.color-btn');
 
   let currentTextStyle = {
     text: '',
@@ -119,6 +124,12 @@ jQuery(function($){
       this.classList.add('active');
       currentTextStyle.color = this.dataset.color;
       updateTextPreview();
+    });
+  });
+  mockupColors.forEach(btn => {
+    btn.addEventListener('click', function(){
+      mockupColors.forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
     });
   });
 
@@ -351,28 +362,19 @@ jQuery(function($){
   // Size controls
   const designArea = document.querySelector('.design-area');
   const sizeBtns = document.querySelectorAll('.size-btn');
-  const sizes = {
-    'A4': { w: 550, h: 650 },
-    'A3': { w: 600, h: 750 },
-    'Cœur': { w: 300, h: 300, radius: '50%' },
-    'Poche': { w: 200, h: 200 },
-    'Full': { w: 650, h: 750 }
-  };
-
   sizeBtns.forEach(btn => {
     btn.addEventListener('click', function(){
       sizeBtns.forEach(b => b.classList.remove('active'));
       this.classList.add('active');
-      const label = this.textContent.trim();
-      const opt = sizes[label];
-      if (opt) {
-        designArea.style.width = opt.w + 'px';
-        designArea.style.height = opt.h + 'px';
-        designArea.style.borderRadius = opt.radius || '20px';
+      if (designArea) {
+        designArea.style.width = this.dataset.width + 'px';
+        designArea.style.height = this.dataset.height + 'px';
+        designArea.style.top = this.dataset.top + 'px';
+        designArea.style.left = this.dataset.left + 'px';
+        designArea.style.borderRadius = '20px';
       }
     });
   });
-
   const defaultSizeBtn = document.querySelector('.size-btn');
-  if (defaultSizeBtn) defaultSizeBtn.classList.add('active');
+  if (defaultSizeBtn) defaultSizeBtn.click();
 });

--- a/includes/class-winshirt-mockups.php
+++ b/includes/class-winshirt-mockups.php
@@ -1,0 +1,136 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WinShirt_Mockups {
+
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'add_meta_boxes', [ $this, 'register_meta_boxes' ] );
+        add_action( 'save_post_ws-mockup', [ $this, 'save_meta' ], 10, 2 );
+    }
+
+    public function register_cpt() {
+        $labels = [
+            'name'          => __( 'Mockups', 'winshirt' ),
+            'singular_name' => __( 'Mockup', 'winshirt' ),
+        ];
+
+        $args = [
+            'labels'       => $labels,
+            'public'       => false,
+            'show_ui'      => true,
+            'show_in_menu' => 'winshirt',
+            'supports'     => [ 'title' ],
+            'menu_position'=> 5,
+        ];
+
+        register_post_type( 'ws-mockup', $args );
+    }
+
+    public function register_meta_boxes() {
+        add_meta_box( 'ws_mockup_images', __( 'Images', 'winshirt' ), [ $this, 'images_box' ], 'ws-mockup', 'normal', 'default' );
+        add_meta_box( 'ws_mockup_colors', __( 'Couleurs', 'winshirt' ), [ $this, 'colors_box' ], 'ws-mockup', 'normal', 'default' );
+        add_meta_box( 'ws_mockup_zones', __( "Zones d'impression", 'winshirt' ), [ $this, 'zones_box' ], 'ws-mockup', 'normal', 'default' );
+    }
+
+    public function images_box( $post ) {
+        wp_nonce_field( 'ws_mockup_save', 'ws_mockup_nonce' );
+        $front = get_post_meta( $post->ID, '_ws_mockup_front', true );
+        $back  = get_post_meta( $post->ID, '_ws_mockup_back', true );
+        echo '<p><label>' . esc_html__( 'Image avant URL', 'winshirt' ) . '</label><input type="text" class="widefat" name="ws_mockup_front" value="' . esc_attr( $front ) . '"/></p>';
+        echo '<p><label>' . esc_html__( 'Image arrière URL', 'winshirt' ) . '</label><input type="text" class="widefat" name="ws_mockup_back" value="' . esc_attr( $back ) . '"/></p>';
+    }
+
+    public function colors_box( $post ) {
+        $colors = get_post_meta( $post->ID, '_ws_mockup_colors', true );
+        echo '<p><label>' . esc_html__( 'Couleurs (hex, séparées par des virgules)', 'winshirt' ) . '</label>';
+        echo '<input type="text" class="widefat" name="ws_mockup_colors" value="' . esc_attr( $colors ) . '"/></p>';
+    }
+
+    public function zones_box( $post ) {
+        $zones = get_post_meta( $post->ID, '_ws_mockup_zones', true );
+        if ( ! is_array( $zones ) ) {
+            $zones = [];
+        }
+        echo '<table class="widefat" id="ws-mockup-zones-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Nom', 'winshirt' ) . '</th><th>' . esc_html__( 'Largeur', 'winshirt' ) . '</th><th>' . esc_html__( 'Hauteur', 'winshirt' ) . '</th><th>' . esc_html__( 'Top', 'winshirt' ) . '</th><th>' . esc_html__( 'Left', 'winshirt' ) . '</th><th>' . esc_html__( 'Prix', 'winshirt' ) . '</th><th></th></tr></thead><tbody>';
+        foreach ( $zones as $index => $zone ) {
+            $name  = esc_attr( $zone['name'] ?? '' );
+            $width = esc_attr( $zone['width'] ?? '' );
+            $height= esc_attr( $zone['height'] ?? '' );
+            $top   = esc_attr( $zone['top'] ?? '' );
+            $left  = esc_attr( $zone['left'] ?? '' );
+            $price = esc_attr( $zone['price'] ?? '' );
+            echo '<tr>';
+            echo '<td><input type="text" name="ws_mockup_zones[' . $index . '][name]" value="' . $name . '" /></td>';
+            echo '<td><input type="number" step="0.01" name="ws_mockup_zones[' . $index . '][width]" value="' . $width . '" /></td>';
+            echo '<td><input type="number" step="0.01" name="ws_mockup_zones[' . $index . '][height]" value="' . $height . '" /></td>';
+            echo '<td><input type="number" step="0.01" name="ws_mockup_zones[' . $index . '][top]" value="' . $top . '" /></td>';
+            echo '<td><input type="number" step="0.01" name="ws_mockup_zones[' . $index . '][left]" value="' . $left . '" /></td>';
+            echo '<td><input type="number" step="0.01" name="ws_mockup_zones[' . $index . '][price]" value="' . $price . '" /></td>';
+            echo '<td><button class="button ws-remove-zone">' . esc_html__( 'Supprimer', 'winshirt' ) . '</button></td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+        echo '<p><button class="button" id="ws-add-zone">' . esc_html__( 'Ajouter une zone', 'winshirt' ) . '</button></p>';
+        ?>
+        <script>
+        jQuery(function($){
+            $('#ws-add-zone').on('click', function(e){
+                e.preventDefault();
+                var rowCount = $('#ws-mockup-zones-table tbody tr').length;
+                var row = '<tr>'+
+                    '<td><input type="text" name="ws_mockup_zones['+rowCount+'][name]" /></td>'+\
+                    '<td><input type="number" step="0.01" name="ws_mockup_zones['+rowCount+'][width]" /></td>'+\
+                    '<td><input type="number" step="0.01" name="ws_mockup_zones['+rowCount+'][height]" /></td>'+\
+                    '<td><input type="number" step="0.01" name="ws_mockup_zones['+rowCount+'][top]" /></td>'+\
+                    '<td><input type="number" step="0.01" name="ws_mockup_zones['+rowCount+'][left]" /></td>'+\
+                    '<td><input type="number" step="0.01" name="ws_mockup_zones['+rowCount+'][price]" /></td>'+\
+                    '<td><button class="button ws-remove-zone"><?php echo esc_js( __( 'Supprimer', 'winshirt' ) ); ?></button></td>'+
+                '</tr>';
+                $('#ws-mockup-zones-table tbody').append(row);
+            });
+            $('#ws-mockup-zones-table').on('click', '.ws-remove-zone', function(e){
+                e.preventDefault();
+                $(this).closest('tr').remove();
+            });
+        });
+        </script>
+        <?php
+    }
+
+    public function save_meta( $post_id, $post ) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! isset( $_POST['ws_mockup_nonce'] ) || ! wp_verify_nonce( $_POST['ws_mockup_nonce'], 'ws_mockup_save' ) ) {
+            return;
+        }
+        if ( $post->post_type !== 'ws-mockup' ) {
+            return;
+        }
+        update_post_meta( $post_id, '_ws_mockup_front', sanitize_text_field( $_POST['ws_mockup_front'] ?? '' ) );
+        update_post_meta( $post_id, '_ws_mockup_back', sanitize_text_field( $_POST['ws_mockup_back'] ?? '' ) );
+        update_post_meta( $post_id, '_ws_mockup_colors', sanitize_text_field( $_POST['ws_mockup_colors'] ?? '' ) );
+
+        $zones = $_POST['ws_mockup_zones'] ?? [];
+        $clean = [];
+        if ( is_array( $zones ) ) {
+            foreach ( $zones as $z ) {
+                $clean[] = [
+                    'name'  => sanitize_text_field( $z['name'] ?? '' ),
+                    'width' => floatval( $z['width'] ?? 0 ),
+                    'height'=> floatval( $z['height'] ?? 0 ),
+                    'top'   => floatval( $z['top'] ?? 0 ),
+                    'left'  => floatval( $z['left'] ?? 0 ),
+                    'price' => floatval( $z['price'] ?? 0 ),
+                ];
+            }
+        }
+        update_post_meta( $post_id, '_ws_mockup_zones', $clean );
+    }
+}
+
+new WinShirt_Mockups();

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -1,3 +1,22 @@
+<?php
+$mockup_id = get_post_meta( get_queried_object_id(), WinShirt_Product_Customization::MOCKUP_META_KEY, true );
+$front = $back = '';
+$colors = [];
+$zones  = [];
+if ( $mockup_id ) {
+    $front = get_post_meta( $mockup_id, '_ws_mockup_front', true );
+    $back  = get_post_meta( $mockup_id, '_ws_mockup_back', true );
+    $color_string = get_post_meta( $mockup_id, '_ws_mockup_colors', true );
+    if ( $color_string ) {
+        $colors = array_filter( array_map( 'trim', explode( ',', $color_string ) ) );
+    }
+    $zones = get_post_meta( $mockup_id, '_ws_mockup_zones', true );
+    if ( ! is_array( $zones ) ) {
+        $zones = [];
+    }
+}
+$default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'left' => 0 ];
+?>
 <div id="winshirt-customizer-modal" class="winshirt-modal-overlay" style="display:none;">
   <div class="winshirt-modal-content">
     <button class="winshirt-modal-close" id="winshirt-close-modal">&times;</button>
@@ -42,13 +61,23 @@
       <!-- Central Area -->
       <main class="central-area">
         <div class="view-controls">
-          <button class="view-btn active">Front</button>
-          <button class="view-btn">Back</button>
+          <button class="view-btn active" data-img="<?php echo esc_url( $front ); ?>">Front</button>
+          <?php if ( $back ) : ?>
+          <button class="view-btn" data-img="<?php echo esc_url( $back ); ?>">Back</button>
+          <?php endif; ?>
         </div>
 
+        <?php if ( ! empty( $colors ) ) : ?>
+        <div class="color-controls">
+          <?php foreach ( $colors as $color ) : ?>
+            <button class="color-btn" data-color="<?php echo esc_attr( $color ); ?>" style="background: <?php echo esc_attr( $color ); ?>;"></button>
+          <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
+
         <div class="tshirt-container">
-          <div class="tshirt">
-            <div class="design-area" id="design-area">
+          <div class="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
+            <div class="design-area" id="design-area" style="width:<?php echo esc_attr( $default_zone['width'] ); ?>px;height:<?php echo esc_attr( $default_zone['height'] ); ?>px;top:<?php echo esc_attr( $default_zone['top'] ); ?>px;left:<?php echo esc_attr( $default_zone['left'] ); ?>px;">
               <div class="layer" id="layer-design">Design Principal</div>
               <div class="layer" id="layer-text"></div>
               <div class="layer" id="layer-qr"></div>
@@ -57,11 +86,11 @@
         </div>
 
         <div class="size-controls">
-          <button class="size-btn">A4</button>
-          <button class="size-btn">A3</button>
-          <button class="size-btn">Cœur</button>
-          <button class="size-btn">Poche</button>
-          <button class="size-btn">Full</button>
+          <?php foreach ( $zones as $zone ) : ?>
+            <button class="size-btn" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
+              <?php echo esc_html( $zone['name'] ); ?>
+            </button>
+          <?php endforeach; ?>
         </div>
       </main>
 

--- a/winshirt.php
+++ b/winshirt.php
@@ -16,6 +16,7 @@ define('WINSHIRT_PATH', plugin_dir_path(__FILE__));
 autoload();
 
 function autoload() {
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-mockups.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-settings.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';


### PR DESCRIPTION
## Summary
- introduce `ws-mockup` admin section for mockup images, colors and print zones
- allow WooCommerce products to select a mockup
- load mockup images/zones in customizer modal with JS controls

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-mockups.php`
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_689084fae6b8832981b341d0a81c3915