### PR TITLE
Fix syntax error in WinShirt_Mockups instantiation

### DIFF
--- a/includes/class-winshirt-mockups.php
+++ b/includes/class-winshirt-mockups.php
@@ -199,4 +199,4 @@ class WinShirt_Mockups {
 }
 
 // Instanciation
-new WinShirt_Mockups
+new WinShirt_Mockups();


### PR DESCRIPTION
## Summary
- fix missing parentheses in `WinShirt_Mockups` instantiation to resolve critical error

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68908ada32388329a4cd0f18f9722139