### PR TITLE
Ensure Mockups menu available in admin

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -68,6 +68,15 @@ class WinShirt_Admin {
             'dashicons-admin-generic'
         );
 
+        // Sous-menu Mockups
+        add_submenu_page(
+            'winshirt',
+            __( 'Mockups', 'winshirt' ),
+            __( 'Mockups', 'winshirt' ),
+            'edit_posts',
+            'edit.php?post_type=ws-mockup'
+        );
+
         // Sous-menu Paramètres (Settings API)
         add_submenu_page(
             'winshirt',

--- a/includes/class-winshirt-mockups.php
+++ b/includes/class-winshirt-mockups.php
@@ -33,14 +33,16 @@ class WinShirt_Mockups {
             'labels'           => $labels,
             'public'           => false,
             'show_ui'          => true,
-            'show_in_menu'     => 'winshirt',
+            // L'édition des mockups est liée à un sous-menu personnalisé
+            // de WinShirt. On désactive donc l'ajout automatique dans le
+            // menu pour éviter les doublons.
+            'show_in_menu'     => false,
             'supports'         => [ 'title' ],
             'menu_position'    => 5,
-            'capability_type'  => 'ws_mockup',
-            'map_meta_cap'     => true,
-            'capabilities'     => [
-                'create_posts' => 'edit_posts',
-            ],
+            // Utilise les capacités standards des articles pour que les
+            // administrateurs puissent accéder aux pages sans droits
+            // supplémentaires.
+            'capability_type'  => 'post',
         ];
 
         register_post_type( 'ws-mockup', $args );


### PR DESCRIPTION
## Summary
- Add explicit Mockups submenu under WinShirt admin menu
- Register Mockups CPT with standard post capabilities and disable automatic menu

## Testing
- `php -l includes/class-winshirt-mockups.php`
- `php -l includes/class-winshirt-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68908d880278832998ce5458f8f7205e