### PR TITLE
Add admin submenu to create mockups

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -77,6 +77,15 @@ class WinShirt_Admin {
             'edit.php?post_type=ws-mockup'
         );
 
+        // Sous-menu pour créer un nouveau mockup
+        add_submenu_page(
+            'winshirt',
+            __( 'Ajouter un mockup', 'winshirt' ),
+            __( 'Ajouter un mockup', 'winshirt' ),
+            'edit_posts',
+            'post-new.php?post_type=ws-mockup'
+        );
+
         // Sous-menu Paramètres (Settings API)
         add_submenu_page(
             'winshirt',


### PR DESCRIPTION
## Summary
- add menu entry to create a mockup from WinShirt admin

## Testing
- `php -l includes/class-winshirt-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_6890bcf9644083298b0a91c67ad6cd0c