### PR TITLE
Open mockup creation screen from admin menu

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -74,7 +74,7 @@ class WinShirt_Admin {
             __( 'Mockups', 'winshirt' ),
             __( 'Mockups', 'winshirt' ),
             'edit_posts',
-            'edit.php?post_type=ws-mockup'
+            'post-new.php?post_type=ws-mockup'
         );
 
         // Sous-menu Paramètres (Settings API)


### PR DESCRIPTION
## Summary
- Link "Mockups" submenu to the add-new screen so administrators can immediately create mockups

## Testing
- `php -l includes/class-winshirt-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6890c4d1e9308329b915c29434e6f429