### PR TITLE
Enable design element manipulation in customizer

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -169,6 +169,34 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: move;
+}
+
+.layer.selected {
+  outline: 2px dashed #007bff;
+}
+
+.layer .ui-resizable-handle,
+.layer .ui-rotatable-handle {
+  width: 12px;
+  height: 12px;
+  background: #007bff;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  display: none;
+}
+
+.layer .ui-rotatable-handle {
+  position: absolute;
+  top: -25px;
+  left: 50%;
+  margin-left: -6px;
+  cursor: pointer;
+}
+
+.layer.selected .ui-resizable-handle,
+.layer.selected .ui-rotatable-handle {
+  display: block;
 }
 
 .size-controls {

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -59,12 +59,37 @@ jQuery(function($){
 
   const designItems = document.querySelectorAll('.design-item');
   const baseLayer = document.getElementById('layer-design');
+
+  function initLayerInteractions($el){
+    if(!$el.length) return;
+    $el.draggable({ containment: '#design-area' })
+       .resizable({
+         handles: 'n,e,s,w,ne,se,sw,nw',
+         containment: '#design-area'
+       })
+       .rotatable();
+    $el.on('mousedown', function(e){
+      e.stopPropagation();
+      $('.layer').removeClass('selected');
+      $(this).addClass('selected');
+    });
+  }
+
+  initLayerInteractions($('#layer-design'));
+  initLayerInteractions($('#layer-text'));
+  initLayerInteractions($('#layer-qr'));
+
+  $('#design-area').on('mousedown', function(){
+    $('.layer').removeClass('selected');
+  });
+
   designItems.forEach(item => {
     item.addEventListener('click', function(){
       baseLayer.innerHTML = this.innerHTML;
       baseLayer.style.fontSize = '200px';
       baseLayer.style.color = '#333';
       baseLayer.style.display = 'flex';
+      $('#layer-design').trigger('mousedown');
     });
   });
 

--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -113,9 +113,13 @@ class WinShirt_Product_Customization {
 
         // CSS minimal pour le modal
         wp_enqueue_style( 'winshirt-modal-css', plugins_url( 'assets/css/winshirt-modal.css', WINSHIRT_PATH . 'winshirt.php' ), [], WINSHIRT_VERSION );
+        wp_enqueue_style( 'jquery-ui-css', 'https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css', [], '1.13.2' );
 
         // JS pour ouvrir/fermer le modal
-        wp_enqueue_script( 'winshirt-modal-js', plugins_url( 'assets/js/winshirt-modal.js', WINSHIRT_PATH . 'winshirt.php' ), [ 'jquery' ], WINSHIRT_VERSION, true );
+        wp_enqueue_script( 'jquery-ui-draggable' );
+        wp_enqueue_script( 'jquery-ui-resizable' );
+        wp_enqueue_script( 'jquery-ui-rotatable', 'https://cdn.jsdelivr.net/npm/jquery-ui-rotatable@1.1.2/jquery.ui.rotatable.min.js', [ 'jquery-ui-draggable', 'jquery-ui-resizable' ], '1.1.2', true );
+        wp_enqueue_script( 'winshirt-modal-js', plugins_url( 'assets/js/winshirt-modal.js', WINSHIRT_PATH . 'winshirt.php' ), [ 'jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'jquery-ui-rotatable' ], WINSHIRT_VERSION, true );
     }
 }
 


### PR DESCRIPTION
## Summary
- Allow design elements in the visual customizer to be selected and manipulated with drag, resize and rotate handles
- Load jQuery UI and rotatable plugin to provide draggable/resizable/rotatable interactions
- Style selection outlines and handles for better UX

## Testing
- `php -l includes/class-winshirt-product-customization.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891db164e248329b570dff14af6f711