### PR TITLE
Ajout de la gestion des visuels

### DIFF
--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -50,15 +50,24 @@ jQuery(function($){
   });
 
   const filterTabs = document.querySelectorAll('.filter-tab');
+  const designItems = document.querySelectorAll('.design-item');
+  const baseLayer = document.getElementById('layer-design');
+
   filterTabs.forEach(tab => {
     tab.addEventListener('click', function(){
       filterTabs.forEach(t => t.classList.remove('active'));
       this.classList.add('active');
+      const term = this.dataset.term;
+      designItems.forEach(item => {
+        const terms = item.dataset.terms ? item.dataset.terms.split(' ') : [];
+        if (!term || term === 'all' || terms.includes(term)) {
+          item.style.display = 'flex';
+        } else {
+          item.style.display = 'none';
+        }
+      });
     });
   });
-
-  const designItems = document.querySelectorAll('.design-item');
-  const baseLayer = document.getElementById('layer-design');
 
   function initLayerInteractions($el){
     if(!$el.length) return;
@@ -85,11 +94,12 @@ jQuery(function($){
 
   designItems.forEach(item => {
     item.addEventListener('click', function(){
-      baseLayer.innerHTML = this.innerHTML;
-      baseLayer.style.fontSize = '200px';
-      baseLayer.style.color = '#333';
-      baseLayer.style.display = 'flex';
-      $('#layer-design').trigger('mousedown');
+      const img = this.dataset.img;
+      if (img) {
+        baseLayer.innerHTML = `<img src="${img}" alt="" />`;
+        baseLayer.style.display = 'flex';
+        $('#layer-design').trigger('mousedown');
+      }
     });
   });
 

--- a/includes/class-winshirt-designs.php
+++ b/includes/class-winshirt-designs.php
@@ -1,0 +1,71 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WinShirt_Designs {
+
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_post_type' ] );
+        add_action( 'init', [ $this, 'register_taxonomy' ] );
+        add_action( 'after_setup_theme', [ $this, 'ensure_thumbnails' ] );
+    }
+
+    public function register_post_type() {
+        $labels = [
+            'name'               => __( 'Visuels', 'winshirt' ),
+            'singular_name'      => __( 'Visuel', 'winshirt' ),
+            'add_new'            => __( 'Ajouter', 'winshirt' ),
+            'add_new_item'       => __( 'Ajouter un visuel', 'winshirt' ),
+            'edit_item'          => __( 'Modifier le visuel', 'winshirt' ),
+            'new_item'           => __( 'Nouveau visuel', 'winshirt' ),
+            'view_item'          => __( 'Voir le visuel', 'winshirt' ),
+            'search_items'       => __( 'Rechercher des visuels', 'winshirt' ),
+            'not_found'          => __( 'Aucun visuel trouvé', 'winshirt' ),
+            'not_found_in_trash' => __( 'Aucun visuel dans la corbeille', 'winshirt' ),
+            'menu_name'          => __( 'Visuels', 'winshirt' ),
+        ];
+
+        $args = [
+            'labels'          => $labels,
+            'public'          => false,
+            'show_ui'         => true,
+            'show_in_menu'    => 'winshirt',
+            'supports'        => [ 'title', 'thumbnail' ],
+            'capability_type' => 'post',
+        ];
+
+        register_post_type( 'ws-design', $args );
+    }
+
+    public function register_taxonomy() {
+        $labels = [
+            'name'              => __( 'Catégories de visuels', 'winshirt' ),
+            'singular_name'     => __( 'Catégorie de visuel', 'winshirt' ),
+            'search_items'      => __( 'Rechercher des catégories', 'winshirt' ),
+            'all_items'         => __( 'Toutes les catégories', 'winshirt' ),
+            'edit_item'         => __( 'Modifier la catégorie', 'winshirt' ),
+            'update_item'       => __( 'Mettre à jour la catégorie', 'winshirt' ),
+            'add_new_item'      => __( 'Ajouter une nouvelle catégorie', 'winshirt' ),
+            'new_item_name'     => __( 'Nom de la nouvelle catégorie', 'winshirt' ),
+            'menu_name'         => __( 'Catégories de visuels', 'winshirt' ),
+        ];
+
+        $args = [
+            'hierarchical'      => true,
+            'labels'            => $labels,
+            'show_ui'           => true,
+            'show_admin_column' => true,
+            'query_var'         => true,
+            'rewrite'           => [ 'slug' => 'ws-design-category' ],
+        ];
+
+        register_taxonomy( 'ws-design-category', [ 'ws-design' ], $args );
+    }
+
+    public function ensure_thumbnails() {
+        add_theme_support( 'post-thumbnails', [ 'ws-design' ] );
+    }
+}
+
+new WinShirt_Designs();

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -108,17 +108,25 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
       </main>
 
       <!-- Image Panel -->
+      <?php
+        $design_categories = get_terms([
+          'taxonomy'   => 'ws-design-category',
+          'hide_empty' => false,
+        ]);
+        $designs = get_posts([
+          'post_type'      => 'ws-design',
+          'numberposts'    => -1,
+          'post_status'    => 'publish',
+        ]);
+      ?>
       <aside class="right-sidebar" id="image-panel">
         <div class="sidebar-header">
           <h2 class="sidebar-title">Galerie de designs</h2>
           <div class="filter-tabs">
-            <div class="filter-tab active">Tous</div>
-            <div class="filter-tab">Animaux</div>
-            <div class="filter-tab">Nature</div>
-            <div class="filter-tab">Humour</div>
-            <div class="filter-tab">Abstrait</div>
-            <div class="filter-tab">Sport</div>
-            <div class="filter-tab">Vintage</div>
+            <div class="filter-tab active" data-term="all"><?php esc_html_e( 'Tous', 'winshirt' ); ?></div>
+            <?php foreach ( $design_categories as $cat ) : ?>
+              <div class="filter-tab" data-term="<?php echo esc_attr( $cat->slug ); ?>"><?php echo esc_html( $cat->name ); ?></div>
+            <?php endforeach; ?>
           </div>
         </div>
 
@@ -126,21 +134,19 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
           <button class="upload-btn">Upload your own design</button>
 
           <div class="design-grid">
-            <div class="design-item">🦁</div>
-            <div class="design-item">🌲</div>
-            <div class="design-item">😂</div>
-            <div class="design-item">🎨</div>
-            <div class="design-item">⚽</div>
-            <div class="design-item">🎸</div>
-            <div class="design-item">🌙</div>
-            <div class="design-item">🔥</div>
-            <div class="design-item">💎</div>
-            <div class="design-item">🚀</div>
-            <div class="design-item">🌊</div>
-            <div class="design-item">⭐</div>
-            <div class="design-item">🎯</div>
-            <div class="design-item">🌺</div>
-            <div class="design-item">🎭</div>
+            <?php foreach ( $designs as $design ) :
+              $thumb = get_the_post_thumbnail_url( $design->ID, 'thumbnail' );
+              $terms = get_the_terms( $design->ID, 'ws-design-category' );
+              $slugs = $terms ? wp_list_pluck( $terms, 'slug' ) : [];
+            ?>
+              <div class="design-item" data-terms="<?php echo esc_attr( implode( ' ', $slugs ) ); ?>" data-img="<?php echo esc_url( $thumb ); ?>">
+                <?php if ( $thumb ) : ?>
+                  <img src="<?php echo esc_url( $thumb ); ?>" alt="<?php echo esc_attr( get_the_title( $design ) ); ?>" />
+                <?php else : ?>
+                  <?php echo esc_html( get_the_title( $design ) ); ?>
+                <?php endif; ?>
+              </div>
+            <?php endforeach; ?>
           </div>
         </div>
       </aside>

--- a/winshirt.php
+++ b/winshirt.php
@@ -17,6 +17,7 @@ autoload();
 
 function autoload() {
     require_once WINSHIRT_PATH . 'includes/class-winshirt-mockups.php';
+    require_once WINSHIRT_PATH . 'includes/class-winshirt-designs.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-product-customization.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-settings.php';
     require_once WINSHIRT_PATH . 'includes/class-winshirt-lottery.php';


### PR DESCRIPTION
## Summary
- Ajout d'un custom post type `ws-design` et de la taxonomie `ws-design-category`
- Intégration des visuels et catégories dynamiques dans le modal de personnalisation
- Filtrage et insertion des visuels côté front

## Testing
- `php -l winshirt.php`
- `php -l includes/class-winshirt-designs.php`
- `php -l templates/modal-customizer.php`
- `node --check assets/js/winshirt-modal.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_6892003a08bc832981bc834f41f35603