### PR TITLE
Ajout des sous-menus Mockups et Visuels

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -69,13 +69,38 @@ class WinShirt_Admin {
             'dashicons-admin-generic'
         );
 
-        // Sous-menu Mockups
+        // Sous-menus Mockups
         add_submenu_page(
             'winshirt',
-            __( 'Mockups', 'winshirt' ),
-            __( 'Mockups', 'winshirt' ),
+            __( 'Tous les mockups', 'winshirt' ),
+            __( 'Tous les mockups', 'winshirt' ),
+            'edit_posts',
+            'edit.php?post_type=ws-mockup'
+        );
+
+        add_submenu_page(
+            'winshirt',
+            __( 'Ajouter un mockup', 'winshirt' ),
+            __( 'Ajouter un mockup', 'winshirt' ),
             'edit_posts',
             'post-new.php?post_type=ws-mockup'
+        );
+
+        // Sous-menus Visuels
+        add_submenu_page(
+            'winshirt',
+            __( 'Visuels', 'winshirt' ),
+            __( 'Visuels', 'winshirt' ),
+            'edit_posts',
+            'edit.php?post_type=ws-design'
+        );
+
+        add_submenu_page(
+            'winshirt',
+            __( 'Ajouter un visuel', 'winshirt' ),
+            __( 'Ajouter un visuel', 'winshirt' ),
+            'edit_posts',
+            'post-new.php?post_type=ws-design'
         );
 
         // Sous-menu Paramètres (Settings API)

--- a/includes/class-winshirt-designs.php
+++ b/includes/class-winshirt-designs.php
@@ -37,7 +37,8 @@ class WinShirt_Designs {
             'public'             => false,
             'show_ui'            => true,
             // Place ce CPT sous le menu WinShirt principal
-            'show_in_menu'       => 'winshirt',
+            // L'affichage du CPT dans le menu est géré manuellement
+            'show_in_menu'       => false,
             'supports'           => [ 'title', 'thumbnail' ],
             'capability_type'    => 'post',
             'map_meta_cap'       => true,


### PR DESCRIPTION
## Résumé
- Ajout des sous-menus "Tous les mockups" et "Ajouter un mockup" dans l'administration de WinShirt
- Ajout des sous-menus "Visuels" et "Ajouter un visuel" pour gérer les visuels
- Ajustement de l'enregistrement du CPT "ws-design" afin de gérer manuellement son affichage dans le menu

## Tests
- `php -l includes/class-winshirt-admin.php`
- `php -l includes/class-winshirt-designs.php`


------
https://chatgpt.com/codex/tasks/task_e_68932168c324832987b2c4dc3d7d6b5a