### PR TITLE
Add admin submenu for all visuals

### DIFF
--- a/includes/class-winshirt-admin.php
+++ b/includes/class-winshirt-admin.php
@@ -89,8 +89,8 @@ class WinShirt_Admin {
         // Sous-menus Visuels
         add_submenu_page(
             'winshirt',
-            __( 'Visuels', 'winshirt' ),
-            __( 'Visuels', 'winshirt' ),
+            __( 'Tous les visuels', 'winshirt' ),
+            __( 'Tous les visuels', 'winshirt' ),
             'edit_posts',
             'edit.php?post_type=ws-design'
         );
@@ -115,7 +115,6 @@ class WinShirt_Admin {
     }
 
     public function cleanup_menu() {
-        remove_submenu_page( 'winshirt', 'edit.php?post_type=ws-design' );
         remove_submenu_page( 'winshirt', 'edit-tags.php?taxonomy=ws-design-category&post_type=ws-design' );
     }
 


### PR DESCRIPTION
## Summary
- add "Tous les visuels" submenu under WinShirt admin menu
- keep design list menu visible by adjusting menu cleanup

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68932a8716288329ab0c9cd82b37f2ed