### PR TITLE
Add interact.js design area with draggable and resizable image

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -146,10 +146,6 @@
 
 .design-area {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 600px;
-  height: 650px;
   border: 3px dashed #dee2e6;
   border-radius: 20px;
   display: flex;
@@ -158,6 +154,14 @@
   color: #6c757d;
   font-size: 18px;
   background: rgba(248, 249, 250, 0.4);
+}
+
+.draggable-item {
+  position: absolute;
+  top: 0;
+  left: 0;
+  cursor: move;
+  touch-action: none;
 }
 
 .layer {

--- a/assets/js/design-area.js
+++ b/assets/js/design-area.js
@@ -1,0 +1,105 @@
+(function(){
+  // Ensure interact.js and localized data are available
+  const zone = window.winshirtDesign ? window.winshirtDesign.zone : null;
+  const designArea = document.getElementById('design-area');
+  if(!designArea || !zone){ return; }
+
+  // apply zone dimensions
+  function applyZone(z){
+    designArea.style.width  = z.width + 'px';
+    designArea.style.height = z.height + 'px';
+    designArea.style.top    = z.top + 'px';
+    designArea.style.left   = z.left + 'px';
+  }
+  applyZone(zone);
+
+  // listen to size buttons to change zone
+  document.querySelectorAll('.size-btn').forEach(btn => {
+    btn.addEventListener('click', function(){
+      const newZone = {
+        width: parseInt(this.dataset.width,10),
+        height: parseInt(this.dataset.height,10),
+        top: parseInt(this.dataset.top,10),
+        left: parseInt(this.dataset.left,10)
+      };
+      applyZone(newZone);
+      fitItem();
+    });
+  });
+
+  const item = designArea.querySelector('.draggable-item');
+  const dataInput = document.getElementById('design-coords');
+  let coords = { x: 0, y: 0, w: 0, h: 0 };
+
+  function updateData(){
+    if(dataInput){ dataInput.value = JSON.stringify(coords); }
+  }
+
+  // fit image to zone
+  function fitItem(){
+    if(!item || !item.naturalWidth){ return; }
+    const areaRatio = zone.width / zone.height;
+    const imgRatio  = item.naturalWidth / item.naturalHeight;
+    if(imgRatio > areaRatio){
+      item.style.width  = '100%';
+      item.style.height = 'auto';
+    } else {
+      item.style.width  = 'auto';
+      item.style.height = '100%';
+    }
+    coords.w = item.offsetWidth;
+    coords.h = item.offsetHeight;
+    coords.x = (zone.width - coords.w) / 2;
+    coords.y = (zone.height - coords.h) / 2;
+    item.style.transform = `translate(${coords.x}px, ${coords.y}px)`;
+    updateData();
+  }
+
+  if(item){
+    item.addEventListener('load', fitItem);
+  }
+
+  // drag & resize with interact.js
+  interact(item).draggable({
+    modifiers: [
+      interact.modifiers.restrictRect({ restriction: designArea, endOnly: true })
+    ],
+    listeners: {
+      move(event){
+        coords.x += event.dx;
+        coords.y += event.dy;
+        event.target.style.transform = `translate(${coords.x}px, ${coords.y}px)`;
+        updateData();
+      }
+    }
+  }).resizable({
+    edges: { left: true, right: true, bottom: true, top: true },
+    modifiers: [
+      interact.modifiers.restrictEdges({ outer: designArea }),
+      interact.modifiers.restrictSize({
+        min: { width: 20, height: 20 },
+        max: { width: zone.width, height: zone.height }
+      })
+    ],
+    listeners: {
+      move(event){
+        coords.x += event.deltaRect.left;
+        coords.y += event.deltaRect.top;
+        coords.w = event.rect.width;
+        coords.h = event.rect.height;
+        Object.assign(event.target.style, {
+          width: coords.w + 'px',
+          height: coords.h + 'px',
+          transform: `translate(${coords.x}px, ${coords.y}px)`
+        });
+        updateData();
+      }
+    }
+  });
+
+  // listen for external design load
+  document.addEventListener('winshirt:load-design', function(e){
+    if(!item) return;
+    item.src = e.detail.src;
+  });
+})();

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -144,7 +144,8 @@ jQuery(function($){
     item.addEventListener('click', function(){
       const img = this.dataset.img;
       if (img) {
-        createLayer('Image', `<img src="${img}" alt="" />`);
+        const evt = new CustomEvent('winshirt:load-design', { detail: { src: img } });
+        document.dispatchEvent(evt);
       }
     });
   });

--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -120,6 +120,21 @@ class WinShirt_Product_Customization {
         wp_enqueue_script( 'jquery-ui-resizable' );
         wp_enqueue_script( 'jquery-ui-rotatable', 'https://cdn.jsdelivr.net/npm/jquery-ui-rotatable@1.1.2/jquery.ui.rotatable.min.js', [ 'jquery-ui-draggable', 'jquery-ui-resizable' ], '1.1.2', true );
         wp_enqueue_script( 'winshirt-modal-js', plugins_url( 'assets/js/winshirt-modal.js', WINSHIRT_PATH . 'winshirt.php' ), [ 'jquery', 'jquery-ui-draggable', 'jquery-ui-resizable', 'jquery-ui-rotatable' ], WINSHIRT_VERSION, true );
+
+        // Interact.js for draggable/resizable zone
+        wp_enqueue_script( 'interactjs', 'https://cdn.jsdelivr.net/npm/@interactjs/interactjs/index.min.js', [], '1.10.17', true );
+        wp_enqueue_script( 'winshirt-design-area', plugins_url( 'assets/js/design-area.js', WINSHIRT_PATH . 'winshirt.php' ), [ 'interactjs' ], WINSHIRT_VERSION, true );
+
+        $mockup_id = get_post_meta( $product_id, self::MOCKUP_META_KEY, true );
+        $zones     = $mockup_id ? get_post_meta( $mockup_id, '_ws_mockup_zones', true ) : [];
+        if ( ! is_array( $zones ) ) {
+            $zones = [];
+        }
+        $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'left' => 0 ];
+
+        wp_localize_script( 'winshirt-design-area', 'winshirtDesign', [
+            'zone' => $default_zone,
+        ] );
     }
 }
 

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -97,9 +97,12 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
 
         <div class="tshirt-container">
           <div class="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
-            <div class="design-area" id="design-area" style="width:<?php echo esc_attr( $default_zone['width'] ); ?>px;height:<?php echo esc_attr( $default_zone['height'] ); ?>px;top:<?php echo esc_attr( $default_zone['top'] ); ?>px;left:<?php echo esc_attr( $default_zone['left'] ); ?>px;"></div>
+            <div class="design-area" id="design-area">
+              <img id="design-item" class="draggable-item" src="" alt="" />
+            </div>
           </div>
         </div>
+        <input type="hidden" id="design-coords" name="design_coords" value="" />
 
         <div class="size-controls">
           <?php foreach ( $zones as $zone ) : ?>


### PR DESCRIPTION
## Summary
- load print-zone metrics into JS and enqueue interact.js
- generate design area with draggable/resizable item
- style design area and draggable item

## Testing
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933d1d08288329916b580362555ca2