### PR TITLE
feat: mobile customizer modal and live design update

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -446,16 +446,62 @@
 @media (max-width: 768px) {
   .main-container {
     flex-direction: column;
-  }
-  
-  .left-sidebar, .right-sidebar {
-    width: 100%;
+    padding-bottom: 80px;
     height: auto;
   }
-  
+
   .left-sidebar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
     flex-direction: row;
+    justify-content: flex-start;
+    gap: 10px;
     padding: 10px;
-    justify-content: center;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    background: #fff;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+    z-index: 1000;
   }
+
+  .right-sidebar {
+    display: none;
+  }
+
+  .mobile-panel {
+    display: block;
+  }
+}
+
+.mobile-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #fff;
+  z-index: 1001;
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform .3s ease;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.mobile-panel.open {
+  transform: translateY(0);
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.panel-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
 }

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -23,17 +23,54 @@ jQuery(function($){
   // Interactive functionality
   const toolIcons = document.querySelectorAll('.tool-icon');
   const panels = document.querySelectorAll('.right-sidebar');
+  const isMobile = window.matchMedia('(max-width: 768px)').matches;
+  let activePanel = null;
+
+  function openPanel(panel){
+    if (!panel) return;
+    if (isMobile) {
+      activePanel = panel;
+      panel.classList.add('open');
+      document.body.style.overflow = 'hidden';
+    } else {
+      panels.forEach(p => p.style.display = 'none');
+      panel.style.display = 'flex';
+    }
+  }
+
+  function closeActivePanel(){
+    if (!isMobile) return;
+    if (activePanel){
+      activePanel.classList.remove('open');
+      document.body.style.overflow = '';
+      activePanel = null;
+    }
+  }
+
+  if (isMobile) {
+    panels.forEach(p => {
+      p.classList.add('mobile-panel');
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'panel-close';
+      closeBtn.innerHTML = '&times;';
+      closeBtn.addEventListener('click', closeActivePanel);
+      p.prepend(closeBtn);
+      let startY = 0;
+      p.addEventListener('touchstart', e => { startY = e.touches[0].clientY; });
+      p.addEventListener('touchend', e => {
+        const dy = e.changedTouches[0].clientY - startY;
+        if (dy > 50) closeActivePanel();
+      });
+    });
+  }
 
   toolIcons.forEach(icon => {
     icon.addEventListener('click', function(){
       toolIcons.forEach(i => i.classList.remove('active'));
       this.classList.add('active');
-      panels.forEach(p => p.style.display = 'none');
       const target = this.dataset.target;
-      if (target) {
-        const panel = document.querySelector(target);
-        if (panel) panel.style.display = 'flex';
-      }
+      const panel = target ? document.querySelector(target) : null;
+      openPanel(panel);
     });
   });
 
@@ -52,6 +89,7 @@ jQuery(function($){
   const filterTabs = document.querySelectorAll('.filter-tab');
   const designItems = document.querySelectorAll('.design-item');
   const designArea  = document.getElementById('design-area');
+  const designImg   = document.getElementById('design-item');
 
   filterTabs.forEach(tab => {
     tab.addEventListener('click', function(){
@@ -144,8 +182,10 @@ jQuery(function($){
     item.addEventListener('click', function(){
       const img = this.dataset.img;
       if (img) {
+        if (designImg) designImg.src = img;
         const evt = new CustomEvent('winshirt:load-design', { detail: { src: img } });
         document.dispatchEvent(evt);
+        if (isMobile) closeActivePanel();
       }
     });
   });
@@ -262,6 +302,7 @@ jQuery(function($){
         currentTextLayer = createLayer('Texte', '');
       }
       updateTextPreview();
+      if (isMobile) closeActivePanel();
     });
   }
 
@@ -402,6 +443,7 @@ jQuery(function($){
       } else {
         currentQrLayer.innerHTML = qrPreview.innerHTML;
       }
+      if (isMobile) closeActivePanel();
     });
   }
 


### PR DESCRIPTION
## Summary
- place mobile control bar at bottom and open panels as full-screen modals with slide animation
- update mockup immediately when selecting a design and close panels on selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689347a9945c8329bce04ecd5d8010c4