### PR TITLE
Enable dynamic mockup zone selection

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -225,6 +225,12 @@
   border-color: #007bff;
 }
 
+.size-btn.active {
+  background: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
 .color-controls {
   display: flex;
   gap: 10px;

--- a/assets/js/design-area.js
+++ b/assets/js/design-area.js
@@ -1,21 +1,26 @@
 (function(){
   // Ensure interact.js and localized data are available
-  const zone = window.winshirtDesign ? window.winshirtDesign.zone : null;
+  let zone = window.winshirtDesign ? window.winshirtDesign.zone : null;
   const designArea = document.getElementById('design-area');
   if(!designArea || !zone){ return; }
 
   // apply zone dimensions
   function applyZone(z){
+    zone = z;
     designArea.style.width  = z.width + 'px';
     designArea.style.height = z.height + 'px';
     designArea.style.top    = z.top + 'px';
     designArea.style.left   = z.left + 'px';
+    initResizable();
   }
   applyZone(zone);
 
   // listen to size buttons to change zone
-  document.querySelectorAll('.size-btn').forEach(btn => {
+  const sizeButtons = document.querySelectorAll('.size-btn');
+  sizeButtons.forEach(btn => {
     btn.addEventListener('click', function(){
+      sizeButtons.forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
       const newZone = {
         width: parseInt(this.dataset.width,10),
         height: parseInt(this.dataset.height,10),
@@ -72,30 +77,37 @@
         updateData();
       }
     }
-  }).resizable({
-    edges: { left: true, right: true, bottom: true, top: true },
-    modifiers: [
-      interact.modifiers.restrictEdges({ outer: designArea }),
-      interact.modifiers.restrictSize({
-        min: { width: 20, height: 20 },
-        max: { width: zone.width, height: zone.height }
-      })
-    ],
-    listeners: {
-      move(event){
-        coords.x += event.deltaRect.left;
-        coords.y += event.deltaRect.top;
-        coords.w = event.rect.width;
-        coords.h = event.rect.height;
-        Object.assign(event.target.style, {
-          width: coords.w + 'px',
-          height: coords.h + 'px',
-          transform: `translate(${coords.x}px, ${coords.y}px)`
-        });
-        updateData();
-      }
-    }
   });
+
+  function initResizable(){
+    if(!item) return;
+    interact(item).resizable({
+      edges: { left: true, right: true, bottom: true, top: true },
+      modifiers: [
+        interact.modifiers.restrictEdges({ outer: designArea }),
+        interact.modifiers.restrictSize({
+          min: { width: 20, height: 20 },
+          max: { width: zone.width, height: zone.height }
+        })
+      ],
+      listeners: {
+        move(event){
+          coords.x += event.deltaRect.left;
+          coords.y += event.deltaRect.top;
+          coords.w = event.rect.width;
+          coords.h = event.rect.height;
+          Object.assign(event.target.style, {
+            width: coords.w + 'px',
+            height: coords.h + 'px',
+            transform: `translate(${coords.x}px, ${coords.y}px)`
+          });
+          updateData();
+        }
+      }
+    });
+  }
+
+  initResizable();
 
   // listen for external design load
   document.addEventListener('winshirt:load-design', function(e){


### PR DESCRIPTION
## Summary
- Update design-area logic to apply dimensions from selected zone and refresh resizable limits
- Highlight active zone button with new CSS styles

## Testing
- `node --check assets/js/design-area.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936be367e483298a513d770bcdffe7