### PR TITLE
Enable dynamic mockup zone selection

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -225,6 +225,12 @@
   border-color: #007bff;
 }
 
+.size-btn.active {
+  background: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
 .color-controls {
   display: flex;
   gap: 10px;

--- a/assets/js/design-area.js
+++ b/assets/js/design-area.js
@@ -1,21 +1,26 @@
 (function(){
   // Ensure interact.js and localized data are available
-  const zone = window.winshirtDesign ? window.winshirtDesign.zone : null;
+  let zone = window.winshirtDesign ? window.winshirtDesign.zone : null;
   const designArea = document.getElementById('design-area');
   if(!designArea || !zone){ return; }
 
   // apply zone dimensions
   function applyZone(z){
+    zone = z;
     designArea.style.width  = z.width + 'px';
     designArea.style.height = z.height + 'px';
     designArea.style.top    = z.top + 'px';
     designArea.style.left   = z.left + 'px';
+    initResizable();
   }
   applyZone(zone);
 
   // listen to size buttons to change zone
-  document.querySelectorAll('.size-btn').forEach(btn => {
+  const sizeButtons = document.querySelectorAll('.size-btn');
+  sizeButtons.forEach(btn => {
     btn.addEventListener('click', function(){
+      sizeButtons.forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
       const newZone = {
         width: parseInt(this.dataset.width,10),
         height: parseInt(this.dataset.height,10),
@@ -72,30 +77,37 @@
         updateData();
       }
     }
-  }).resizable({
-    edges: { left: true, right: true, bottom: true, top: true },
-    modifiers: [
-      interact.modifiers.restrictEdges({ outer: designArea }),
-      interact.modifiers.restrictSize({
-        min: { width: 20, height: 20 },
-        max: { width: zone.width, height: zone.height }
-      })
-    ],
-    listeners: {
-      move(event){
-        coords.x += event.deltaRect.left;
-        coords.y += event.deltaRect.top;
-        coords.w = event.rect.width;
-        coords.h = event.rect.height;
-        Object.assign(event.target.style, {
-          width: coords.w + 'px',
-          height: coords.h + 'px',
-          transform: `translate(${coords.x}px, ${coords.y}px)`
-        });
-        updateData();
-      }
-    }
   });
+
+  function initResizable(){
+    if(!item) return;
+    interact(item).resizable({
+      edges: { left: true, right: true, bottom: true, top: true },
+      modifiers: [
+        interact.modifiers.restrictEdges({ outer: designArea }),
+        interact.modifiers.restrictSize({
+          min: { width: 20, height: 20 },
+          max: { width: zone.width, height: zone.height }
+        })
+      ],
+      listeners: {
+        move(event){
+          coords.x += event.deltaRect.left;
+          coords.y += event.deltaRect.top;
+          coords.w = event.rect.width;
+          coords.h = event.rect.height;
+          Object.assign(event.target.style, {
+            width: coords.w + 'px',
+            height: coords.h + 'px',
+            transform: `translate(${coords.x}px, ${coords.y}px)`
+          });
+          updateData();
+        }
+      }
+    });
+  }
+
+  initResizable();
 
   // listen for external design load
   document.addEventListener('winshirt:load-design', function(e){

--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -133,7 +133,8 @@ class WinShirt_Product_Customization {
         $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'left' => 0 ];
 
         wp_localize_script( 'winshirt-design-area', 'winshirtDesign', [
-            'zone' => $default_zone,
+            'zone'  => $default_zone,
+            'zones' => array_values( $zones ),
         ] );
     }
 }

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -104,13 +104,15 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
         </div>
         <input type="hidden" id="design-coords" name="design_coords" value="" />
 
+        <?php if ( ! empty( $zones ) ) : ?>
         <div class="size-controls">
-          <?php foreach ( $zones as $zone ) : ?>
-            <button class="size-btn" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
+          <?php foreach ( $zones as $i => $zone ) : ?>
+            <button class="size-btn<?php echo $i === 0 ? ' active' : ''; ?>" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
               <?php echo esc_html( $zone['name'] ); ?>
             </button>
           <?php endforeach; ?>
         </div>
+        <?php endif; ?>
       </main>
 
       <!-- Image Panel -->


### PR DESCRIPTION
## Summary
- Render zone selection buttons in the customizer when mockup zones exist and set the first zone active by default
- Localize the list of mockup zones so the design area script has access to all zone data

## Testing
- `php -l templates/modal-customizer.php`
- `php -l includes/class-winshirt-product-customization.php`
- `node --check assets/js/design-area.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936be367e483298a513d770bcdffe7