### PR TITLE
Display mockup print zones with inline controls

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -208,6 +208,7 @@
   gap: 15px;
   flex-wrap: wrap;
   justify-content: center;
+  margin-top: 20px;
 }
 
 .size-btn {

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -481,21 +481,4 @@ jQuery(function($){
     });
   }
 
-  // Size controls
-  const sizeBtns = document.querySelectorAll('.size-btn');
-  sizeBtns.forEach(btn => {
-    btn.addEventListener('click', function(){
-      sizeBtns.forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
-      if (designArea) {
-        designArea.style.width = this.dataset.width + 'px';
-        designArea.style.height = this.dataset.height + 'px';
-        designArea.style.top = this.dataset.top + 'px';
-        designArea.style.left = this.dataset.left + 'px';
-        designArea.style.borderRadius = '20px';
-      }
-    });
-  });
-  const defaultSizeBtn = document.querySelector('.size-btn');
-  if (defaultSizeBtn) defaultSizeBtn.click();
 });

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -101,18 +101,17 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
               <img id="design-item" class="draggable-item" src="" alt="" />
             </div>
           </div>
+          <?php if ( ! empty( $zones ) ) : ?>
+          <div class="size-controls">
+            <?php foreach ( $zones as $i => $zone ) : ?>
+              <button class="size-btn<?php echo $i === 0 ? ' active' : ''; ?>" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
+                <?php echo esc_html( $zone['name'] ); ?>
+              </button>
+            <?php endforeach; ?>
+          </div>
+          <?php endif; ?>
         </div>
         <input type="hidden" id="design-coords" name="design_coords" value="" />
-
-        <?php if ( ! empty( $zones ) ) : ?>
-        <div class="size-controls">
-          <?php foreach ( $zones as $i => $zone ) : ?>
-            <button class="size-btn<?php echo $i === 0 ? ' active' : ''; ?>" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
-              <?php echo esc_html( $zone['name'] ); ?>
-            </button>
-          <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
       </main>
 
       <!-- Image Panel -->


### PR DESCRIPTION
## Summary
- Place print area buttons directly beneath the T-shirt preview
- Drop duplicate size control JS and leave sizing to design-area logic
- Add top margin to print zone control buttons

## Testing
- `php -l templates/modal-customizer.php`
- `node --check assets/js/winshirt-modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68944ec1e4388329b67912254bb760b8