### PR TITLE
Add print zone selector with side support

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -101,25 +101,24 @@
 
 }
 
-.view-controls {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 30px;
+.view-controls{
+  display:flex;
+  gap:12px;
+  margin:16px 0 10px;
 }
 
-.view-btn {
-  padding: 8px 20px;
-  border: 2px solid #dee2e6;
-  background: white;
-  border-radius: 25px;
-  cursor: pointer;
-  transition: all 0.3s;
+.view-btn{
+  padding:8px 16px;
+  border:2px solid #dee2e6;
+  background:#fff;
+  border-radius:25px;
+  cursor:pointer;
 }
 
-.view-btn.active {
-  background: #007bff;
-  color: white;
-  border-color: #007bff;
+.view-btn[aria-pressed='true']{
+  background:#007bff;
+  color:white;
+  border-color:#007bff;
 }
 
 .tshirt-container {
@@ -154,11 +153,10 @@
   color: #6c757d;
   font-size: 18px;
   background: rgba(248, 249, 250, 0.4);
-  margin-top: -50px;
-  width: 600px;
-  height: 600px;
   top: 0;
   left: 0;
+  width: 200px;
+  height: 200px;
 }
 
 .draggable-item {
@@ -214,35 +212,6 @@
 .layer.selected .ui-resizable-handle,
 .layer.selected .ui-rotatable-handle {
   display: block;
-}
-
-.size-controls {
-  display: flex;
-  gap: 15px;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-top: 20px;
-}
-
-.size-btn {
-  padding: 8px 16px;
-  border: 1px solid #dee2e6;
-  background: white;
-  border-radius: 20px;
-  cursor: pointer;
-  transition: all 0.3s;
-  font-size: 12px;
-}
-
-.size-btn:hover {
-  background: #f8f9fa;
-  border-color: #007bff;
-}
-
-.size-btn.active {
-  background: #007bff;
-  color: white;
-  border-color: #007bff;
 }
 
 .color-controls {
@@ -543,3 +512,9 @@
   font-size: 24px;
   line-height: 1;
 }
+.printzones-bar{display:flex;gap:10px;flex-wrap:wrap;margin:16px 0 0;max-width:800px}
+@media(max-width:768px){.printzones-bar{overflow-x:auto;flex-wrap:nowrap;padding-bottom:6px}}
+.zone-btn{padding:8px 14px;border:1px solid #e0e0e0;background:#fff;border-radius:18px;cursor:pointer;font-size:12px;white-space:nowrap}
+.zone-btn.active{background:#2d2d2d;color:#fff;border-color:#2d2d2d}
+.zone-btn:disabled{opacity:.5;cursor:not-allowed}
+.printzones-empty{font-size:12px;color:#666;padding:8px 0}

--- a/assets/js/printzones.js
+++ b/assets/js/printzones.js
@@ -1,0 +1,113 @@
+(function(){
+  const cfg = window.WINSHIRT_CONFIG || {};
+  const tshirt = document.getElementById('tshirt');
+  const designArea = document.getElementById('design-area');
+  const bar = document.getElementById('printzones-bar');
+  const viewControls = document.getElementById('view-controls');
+  if(!tshirt || !designArea || !bar || !viewControls){ return; }
+
+  let state = {
+    side: (sessionStorage.getItem('ws_side') || cfg.activeSide || 'front'),
+    zoneKey: sessionStorage.getItem('ws_zoneKey') || null
+  };
+
+  function applySide(side){
+    const sideCfg = cfg.sides && cfg.sides[side];
+    if(!sideCfg){ console.warn('Side config missing:', side); return; }
+    state.side = side;
+    sessionStorage.setItem('ws_side', side);
+
+    if(sideCfg.image){
+      tshirt.style.backgroundImage = `url('${sideCfg.image}')`;
+    }
+
+    renderZoneButtons(sideCfg.zones || []);
+
+    const defaultZone = resolveDefaultZone(sideCfg.zones);
+    if(defaultZone){
+      applyZone(defaultZone);
+    } else {
+      designArea.style.width = '0px';
+      designArea.style.height = '0px';
+      designArea.style.left = '0px';
+      designArea.style.top = '0px';
+      bar.innerHTML += '<div class="printzones-empty">Aucune zone définie pour cette face.</div>';
+    }
+
+    viewControls.querySelectorAll('.view-btn').forEach(btn => {
+      btn.setAttribute('aria-pressed', String(btn.dataset.side === side));
+    });
+  }
+
+  function resolveDefaultZone(zones){
+    if(!zones || !zones.length){ return null; }
+    if(state.zoneKey){
+      const z = zones.find(z => z.key === state.zoneKey);
+      if(z){ return z; }
+    }
+    return zones[0];
+  }
+
+  function renderZoneButtons(zones){
+    bar.innerHTML = '';
+    if(!zones.length){ return; }
+    zones.forEach(z => {
+      const btn = document.createElement('button');
+      btn.className = 'zone-btn';
+      btn.type = 'button';
+      btn.role = 'tab';
+      btn.dataset.key = z.key;
+      btn.textContent = z.label || z.key;
+      btn.setAttribute('aria-pressed','false');
+      btn.addEventListener('click', () => applyZone(z));
+      bar.appendChild(btn);
+    });
+    if(state.zoneKey){
+      const active = bar.querySelector(`.zone-btn[data-key="${state.zoneKey}"]`);
+      if(active){ setActiveZoneButton(active); }
+    }
+  }
+
+  function setActiveZoneButton(btn){
+    bar.querySelectorAll('.zone-btn').forEach(b => {
+      b.classList.remove('active');
+      b.setAttribute('aria-pressed','false');
+    });
+    btn.classList.add('active');
+    btn.setAttribute('aria-pressed','true');
+  }
+
+  function applyZone(zone){
+    if(!zone){ return; }
+    designArea.style.width = zone.w + 'px';
+    designArea.style.height = zone.h + 'px';
+    designArea.style.left = zone.x + 'px';
+    designArea.style.top = zone.y + 'px';
+
+    const btn = bar.querySelector(`.zone-btn[data-key="${zone.key}"]`);
+    if(btn){ setActiveZoneButton(btn); }
+
+    state.zoneKey = zone.key;
+    sessionStorage.setItem('ws_zoneKey', zone.key);
+
+    document.dispatchEvent(new CustomEvent('winshirt:zone-change', {
+      detail: { side: state.side, key: zone.key, box: { w: zone.w, h: zone.h, x: zone.x, y: zone.y } }
+    }));
+  }
+
+  viewControls.addEventListener('click', e => {
+    const btn = e.target.closest('.view-btn');
+    if(!btn){ return; }
+    const side = btn.dataset.side;
+    if(side && side !== state.side){
+      const zones = cfg.sides && cfg.sides[side] ? cfg.sides[side].zones || [] : [];
+      if(!zones.find(z => z.key === state.zoneKey)){
+        state.zoneKey = null;
+        sessionStorage.removeItem('ws_zoneKey');
+      }
+      applySide(side);
+    }
+  });
+
+  applySide(state.side);
+})();

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -80,11 +80,9 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
 
       <!-- Central Area -->
       <main class="central-area">
-        <div class="view-controls">
-          <button class="view-btn active" data-img="<?php echo esc_url( $front ); ?>">Front</button>
-          <?php if ( $back ) : ?>
-          <button class="view-btn" data-img="<?php echo esc_url( $back ); ?>">Back</button>
-          <?php endif; ?>
+        <div class="view-controls" id="view-controls">
+          <button class="view-btn" data-side="front" aria-pressed="true">Recto</button>
+          <button class="view-btn" data-side="back" aria-pressed="false">Verso</button>
         </div>
 
         <?php if ( ! empty( $colors ) ) : ?>
@@ -96,19 +94,12 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
         <?php endif; ?>
 
         <div class="tshirt-container">
-          <div class="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
-            <div class="design-area" id="design-area"></div>
+          <div class="tshirt" id="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
+            <div id="design-area" class="design-area">Zone de design</div>
           </div>
-          <?php if ( ! empty( $zones ) ) : ?>
-          <div class="size-controls">
-            <?php foreach ( $zones as $i => $zone ) : ?>
-              <button class="size-btn<?php echo $i === 0 ? ' active' : ''; ?>" data-width="<?php echo esc_attr( $zone['width'] ); ?>" data-height="<?php echo esc_attr( $zone['height'] ); ?>" data-top="<?php echo esc_attr( $zone['top'] ); ?>" data-left="<?php echo esc_attr( $zone['left'] ); ?>" data-price="<?php echo esc_attr( $zone['price'] ); ?>">
-                <?php echo esc_html( $zone['name'] ); ?>
-              </button>
-            <?php endforeach; ?>
-          </div>
-          <?php endif; ?>
         </div>
+
+        <div class="printzones-bar" id="printzones-bar" aria-label="Zones d'impression" role="tablist"></div>
         <input type="hidden" id="design-coords" name="design_coords" value="" />
       </main>
 


### PR DESCRIPTION
## Summary
- add dynamic print zone bar with Recto/Verso switching and zone events
- adjust design area script to respond to zone changes
- enqueue new config and styles for zone and view buttons

## Testing
- `php -l templates/modal-customizer.php`
- `php -l includes/class-winshirt-product-customization.php`
- `node --check assets/js/printzones.js`
- `node --check assets/js/design-area.js`


------
https://chatgpt.com/codex/tasks/task_e_6897af3285208329b8e31dc713b81d73