### PR TITLE
feat: dynamic print zone controls and image handling

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -512,7 +512,7 @@
   font-size: 24px;
   line-height: 1;
 }
-.printzones-bar{display:flex;gap:10px;flex-wrap:wrap;margin:16px 0 0;max-width:800px}
+.printzones-bar{display:flex;justify-content:center;gap:10px;flex-wrap:wrap;margin:16px 0;max-width:800px}
 @media(max-width:768px){.printzones-bar{overflow-x:auto;flex-wrap:nowrap;padding-bottom:6px}}
 .zone-btn{padding:8px 14px;border:1px solid #e0e0e0;background:#fff;border-radius:18px;cursor:pointer;font-size:12px;white-space:nowrap}
 .zone-btn.active{background:#2d2d2d;color:#fff;border-color:#2d2d2d}

--- a/assets/js/design-area.js
+++ b/assets/js/design-area.js
@@ -2,6 +2,7 @@
   const designArea = document.getElementById('design-area');
   if(!designArea){ return; }
   let zone = null;
+  let ratio = 1;
 
   function applyZone(z){
     zone = z;
@@ -10,8 +11,7 @@
     designArea.style.height = zone.h + 'px';
     designArea.style.top = zone.y + 'px';
     designArea.style.left = zone.x + 'px';
-    initResizable();
-    fitItem();
+    placeItem();
   }
 
   document.addEventListener('winshirt:zone-change', function(e){
@@ -27,26 +27,23 @@
     if(dataInput){ dataInput.value = JSON.stringify(coords); }
   }
 
-  function fitItem(){
+  function placeItem(){
     if(!item || !zone || !item.naturalWidth){ return; }
-    const areaRatio = zone.w / zone.h;
-    const imgRatio  = item.naturalWidth / item.naturalHeight;
-    if(imgRatio > areaRatio){
-      item.style.width = '100%';
-      item.style.height = 'auto';
-    } else {
-      item.style.width = 'auto';
-      item.style.height = '100%';
-    }
-    coords.w = item.offsetWidth;
-    coords.h = item.offsetHeight;
+    ratio = item.naturalWidth / item.naturalHeight || 1;
+    coords.w = zone.w * 0.4;
+    coords.h = coords.w / ratio;
     coords.x = (zone.w - coords.w) / 2;
     coords.y = (zone.h - coords.h) / 2;
-    item.style.transform = `translate(${coords.x}px, ${coords.y}px)`;
+    Object.assign(item.style, {
+      width: coords.w + 'px',
+      height: coords.h + 'px',
+      transform: `translate(${coords.x}px, ${coords.y}px)`
+    });
     updateData();
+    initResizable();
   }
 
-  if(item){ item.addEventListener('load', fitItem); }
+  if(item){ item.addEventListener('load', placeItem); }
 
   interact(item).draggable({
     modifiers: [
@@ -71,7 +68,8 @@
         interact.modifiers.restrictSize({
           min: { width:20, height:20 },
           max: { width: zone.w, height: zone.h }
-        })
+        }),
+        interact.modifiers.aspectRatio({ ratio })
       ],
       listeners: {
         move(event){

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -177,10 +177,8 @@ jQuery(function($){
   function initVisuels() {
     $('.design-item').off('click').on('click', function(){
       const imgSrc = $(this).data('img');
-      const layer = createLayer('Visuel', `<img src="${imgSrc}" style="width:100%;height:auto;">`);
-      $(layer).css({ width: '40%', position: 'absolute', top: '30%', left: '30%' });
+      document.dispatchEvent(new CustomEvent('winshirt:load-design', { detail: { src: imgSrc } }));
       if (isMobile) closePanels();
-      setActiveLayer(layer.id);
     });
   }
 

--- a/includes/class-winshirt-product-customization.php
+++ b/includes/class-winshirt-product-customization.php
@@ -135,11 +135,20 @@ class WinShirt_Product_Customization {
         if ( $back && ! filter_var( $back, FILTER_VALIDATE_URL ) ) {
             $back = wp_get_attachment_url( $back );
         }
-        $zones = $mockup_id ? get_post_meta( $mockup_id, '_ws_mockup_zones', true ) : [];
-        if ( ! is_array( $zones ) ) {
-            $zones = [];
+        $zones_meta = $mockup_id ? get_post_meta( $mockup_id, '_ws_mockup_zones', true ) : [];
+        if ( ! is_array( $zones_meta ) ) {
+            $zones_meta = [];
         }
-        $zones_front = array_map( function( $z ) {
+
+        if ( isset( $zones_meta['front'] ) || isset( $zones_meta['back'] ) ) {
+            $zones_front_raw = $zones_meta['front'] ?? [];
+            $zones_back_raw  = $zones_meta['back']  ?? [];
+        } else {
+            $zones_front_raw = $zones_meta;
+            $zones_back_raw  = [];
+        }
+
+        $format_zone = function( $z ) {
             return [
                 'key'   => $z['name'] ?? '',
                 'label' => $z['name'] ?? '',
@@ -148,14 +157,17 @@ class WinShirt_Product_Customization {
                 'x'     => isset( $z['left'] ) ? intval( $z['left'] ) : 0,
                 'y'     => isset( $z['top'] ) ? intval( $z['top'] ) : 0,
             ];
-        }, $zones );
+        };
+
+        $zones_front = array_map( $format_zone, $zones_front_raw );
+        $zones_back  = array_map( $format_zone, $zones_back_raw );
 
         $config = [
             'mockupId'   => (int) $mockup_id,
             'activeSide' => 'front',
             'sides'      => [
                 'front' => [ 'image' => $front, 'zones' => $zones_front ],
-                'back'  => [ 'image' => $back,  'zones' => [] ],
+                'back'  => [ 'image' => $back,  'zones' => $zones_back ],
             ],
         ];
 

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -80,11 +80,6 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
 
       <!-- Central Area -->
       <main class="central-area">
-        <div class="view-controls" id="view-controls">
-          <button class="view-btn" data-side="front" aria-pressed="true">Recto</button>
-          <button class="view-btn" data-side="back" aria-pressed="false">Verso</button>
-        </div>
-
         <?php if ( ! empty( $colors ) ) : ?>
         <div class="color-controls">
           <?php foreach ( $colors as $color ) : ?>
@@ -95,11 +90,15 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
 
         <div class="tshirt-container">
           <div class="tshirt" id="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
-            <div id="design-area" class="design-area">Zone de design</div>
+            <div id="design-area" class="design-area"><img src="" alt="" class="draggable-item" /></div>
           </div>
         </div>
 
         <div class="printzones-bar" id="printzones-bar" aria-label="Zones d'impression" role="tablist"></div>
+        <div class="view-controls" id="view-controls">
+          <button class="view-btn" data-side="front" aria-pressed="true">Recto</button>
+          <button class="view-btn" data-side="back" aria-pressed="false">Verso</button>
+        </div>
         <input type="hidden" id="design-coords" name="design_coords" value="" />
       </main>
 


### PR DESCRIPTION
## Summary
- center design-area image at 40% width and lock resizing to original aspect ratio
- load designs via event dispatch and reposition print-zone buttons
- expose front/back zone metadata from admin to front-end config

## Testing
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_6898d6cdfab8832994f1e33097df091b