### PR TITLE
Refine WinShirt mockup zones and design handling

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -123,7 +123,8 @@
 
 .tshirt-container {
   position: relative;
-  margin-bottom: 30px;
+  margin-bottom: 12px;
+  transform: translateY(-8px);
 }
 
 .tshirt {
@@ -137,6 +138,9 @@
   justify-content: center;
   position: relative;
   transition: transform 0.3s;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .tshirt:hover {
@@ -147,16 +151,10 @@
   position: absolute;
   border: 3px dashed #dee2e6;
   border-radius: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #6c757d;
-  font-size: 18px;
+  display: block;
   background: rgba(248, 249, 250, 0.4);
   top: 0;
   left: 0;
-  width: 200px;
-  height: 200px;
 }
 
 .draggable-item {
@@ -512,9 +510,7 @@
   font-size: 24px;
   line-height: 1;
 }
-.printzones-bar{display:flex;justify-content:center;gap:10px;flex-wrap:wrap;margin:16px 0;max-width:800px}
-@media(max-width:768px){.printzones-bar{overflow-x:auto;flex-wrap:nowrap;padding-bottom:6px}}
-.zone-btn{padding:8px 14px;border:1px solid #e0e0e0;background:#fff;border-radius:18px;cursor:pointer;font-size:12px;white-space:nowrap}
-.zone-btn.active{background:#2d2d2d;color:#fff;border-color:#2d2d2d}
-.zone-btn:disabled{opacity:.5;cursor:not-allowed}
+.printzones-bar{display:flex;gap:.5rem;justify-content:center;margin-top:.75rem}
+.printzones-btn{padding:.4rem .8rem;border:1px solid #e0e0e0;border-radius:20px;background:#fff;cursor:pointer}
+.printzones-btn.active{background:#111;color:#fff;border-color:#111}
 .printzones-empty{font-size:12px;color:#666;padding:8px 0}

--- a/assets/js/winshirt-modal.js
+++ b/assets/js/winshirt-modal.js
@@ -68,18 +68,6 @@ jQuery(function($){
     }
   });
 
-  const viewBtns = document.querySelectorAll('.view-btn');
-  const tshirt = document.querySelector('.tshirt');
-  viewBtns.forEach(btn => {
-    btn.addEventListener('click', function(){
-      viewBtns.forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
-      if (tshirt && this.dataset.img) {
-        tshirt.style.backgroundImage = `url('${this.dataset.img}')`;
-      }
-    });
-  });
-
   const filterTabs = document.querySelectorAll('.filter-tab');
   const designItems = document.querySelectorAll('.design-item');
   const designArea  = document.getElementById('design-area');
@@ -120,8 +108,11 @@ jQuery(function($){
        .resizable({
          handles: 'n,e,s,w,ne,se,sw,nw',
          containment: '#design-area',
-         minWidth: 50,
-         maxWidth: 500
+         minWidth: 32,
+         minHeight: 32,
+         start: function(event){
+           $(this).resizable('option','aspectRatio', event.originalEvent.shiftKey);
+         }
        })
        .rotatable();
     $el.on('mousedown', function(e){
@@ -176,8 +167,19 @@ jQuery(function($){
   // Initialisation du visuel interactif
   function initVisuels() {
     $('.design-item').off('click').on('click', function(){
-      const imgSrc = $(this).data('img');
-      document.dispatchEvent(new CustomEvent('winshirt:load-design', { detail: { src: imgSrc } }));
+      const url = this.dataset.full || this.dataset.img;
+      const layerDiv = createLayer('Design', `<img src="${url}" alt="" />`);
+      layerDiv.style.width = '120px';
+      layerDiv.style.height = '120px';
+      const img = layerDiv.querySelector('img');
+      if(img){
+        img.style.width = '100%';
+        img.style.height = '100%';
+        img.style.objectFit = 'contain';
+        img.style.pointerEvents = 'none';
+      }
+      $(layerDiv).draggable('option','containment','#design-area')
+                 .resizable('option','containment','#design-area');
       if (isMobile) closePanels();
     });
   }

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -17,8 +17,14 @@ $front = $back = '';
 $colors = [];
 $zones  = [];
 if ( $mockup_id ) {
-    $front = get_post_meta( $mockup_id, '_ws_mockup_front', true );
-    $back  = get_post_meta( $mockup_id, '_ws_mockup_back', true );
+    $front = get_post_meta( $mockup_id, '_winshirt_mockup_front_image', true );
+    $back  = get_post_meta( $mockup_id, '_winshirt_mockup_back_image', true );
+    if ( ! $front ) {
+        $front = get_post_meta( $mockup_id, '_ws_mockup_front', true );
+    }
+    if ( ! $back ) {
+        $back = get_post_meta( $mockup_id, '_ws_mockup_back', true );
+    }
     // Accepte un ID de pièce jointe ou une URL directe
     if ( $front && ! filter_var( $front, FILTER_VALIDATE_URL ) ) {
         $front = wp_get_attachment_url( $front );
@@ -30,7 +36,10 @@ if ( $mockup_id ) {
     if ( $color_string ) {
         $colors = array_filter( array_map( 'trim', explode( ',', $color_string ) ) );
     }
-    $zones = get_post_meta( $mockup_id, '_ws_mockup_zones', true );
+    $zones = get_post_meta( $mockup_id, '_winshirt_mockup_zones', true );
+    if ( empty( $zones ) ) {
+        $zones = get_post_meta( $mockup_id, '_ws_mockup_zones', true );
+    }
     if ( ! is_array( $zones ) ) {
         $zones = [];
     }
@@ -90,7 +99,7 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
 
         <div class="tshirt-container">
           <div class="tshirt" id="tshirt" style="background-image:url('<?php echo esc_url( $front ); ?>'); background-repeat:no-repeat; background-size:contain; background-position:center;">
-            <div id="design-area" class="design-area"><img src="" alt="" class="draggable-item" /></div>
+            <div id="design-area" class="design-area"></div>
           </div>
         </div>
 
@@ -131,10 +140,11 @@ $default_zone = $zones[0] ?? [ 'width' => 600, 'height' => 650, 'top' => 0, 'lef
           <div class="design-grid">
             <?php foreach ( $designs as $design ) :
               $thumb = get_the_post_thumbnail_url( $design->ID, 'thumbnail' );
+              $full  = get_the_post_thumbnail_url( $design->ID, 'full' );
               $terms = get_the_terms( $design->ID, 'ws-design-category' );
               $slugs = $terms ? wp_list_pluck( $terms, 'slug' ) : [];
             ?>
-              <div class="design-item" data-terms="<?php echo esc_attr( implode( ' ', $slugs ) ); ?>" data-img="<?php echo esc_url( $thumb ); ?>">
+              <div class="design-item" data-terms="<?php echo esc_attr( implode( ' ', $slugs ) ); ?>" data-full="<?php echo esc_url( $full ); ?>" data-thumb="<?php echo esc_url( $thumb ); ?>">
                 <?php if ( $thumb ) : ?>
                   <img src="<?php echo esc_url( $thumb ); ?>" alt="<?php echo esc_attr( get_the_title( $design ) ); ?>" />
                 <?php else : ?>


### PR DESCRIPTION
## Summary
- Localize mockup faces and zones to JS and compute design area from ratios
- Use full-resolution design images and jQuery UI containment for layers
- Style print zone controls and design area for clearer customization

## Testing
- `php -l includes/class-winshirt-product-customization.php`
- `php -l templates/modal-customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_6898db7093e88329a4dac8ce4c1ec219