### PR TITLE
feat: compute print zone and element manipulator

### DIFF
--- a/assets/css/winshirt-modal.css
+++ b/assets/css/winshirt-modal.css
@@ -132,22 +132,43 @@
   max-width: 860px;
   height: auto;
   aspect-ratio: var(--ratio, 0.75);
-  background-repeat: no-repeat;
-  background-size: contain;
-  background-position: center;
   margin: 0 auto;
   position: relative;
+}
+
+.tshirt img {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .design-area {
   position: absolute;
   left: 0;
   top: 0;
-  width: 0;
-  height: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.print-zone {
+  position: absolute;
+  pointer-events: none;
   outline: 2px dashed #6aa0ff;
   border-radius: 8px;
+}
+
+.design-element {
+  position: absolute;
+  pointer-events: auto;
+}
+
+.design-element .content {
   pointer-events: none;
+}
+
+.design-element .handle {
+  pointer-events: all;
 }
 
 .draggable-item {

--- a/templates/modal-customizer.php
+++ b/templates/modal-customizer.php
@@ -100,8 +100,12 @@ $default_zone = $zones['front'][0] ?? [ 'width' => 600, 'height' => 650, 'top' =
         </div>
 
         <div class="tshirt-container">
-          <div id="tshirt" class="tshirt"></div>
-          <div id="design-area" class="design-area"></div>
+          <div id="tshirt" class="tshirt">
+            <img id="mockup-img" src="<?php echo esc_url( $front ); ?>" alt="" />
+            <div id="design-area" class="design-area">
+              <div class="print-zone"></div>
+            </div>
+          </div>
         </div>
 
         <div id="printzones-bar" class="printzones-bar" role="tablist"></div>


### PR DESCRIPTION
## Summary
- render mockup image with printable zone overlay
- size print zone dynamically based on mockup dimensions
- add vanilla manipulation module for drag/resize/rotate/delete

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f84300388329a967d2ae827fe4e2